### PR TITLE
feat: add OpenTelemetry instrumentation (JRL-11)

### DIFF
--- a/.syncpackrc.yaml
+++ b/.syncpackrc.yaml
@@ -1,6 +1,6 @@
 # syncpack config — enforce semver range consistency
 semverGroups:
-  - label: "Default — caret ranges"
+  - label: 'Default — caret ranges'
     dependencies:
-      - "**"
-    range: "^"
+      - '**'
+    range: '^'

--- a/README.md
+++ b/README.md
@@ -218,6 +218,56 @@ auth: {
 - `KV.UNSUBSCRIBE`: Unsubscribe from KV changes
 - `KV.UNSUBSCRIBE_ALL`: Unsubscribe from all KV changes
 
+## OpenTelemetry
+
+This library emits OpenTelemetry spans for NATS operations and propagates W3C
+trace context across the wire so a single trace can span publisher, subscriber,
+and request/reply replier.
+
+### Emitted spans
+
+| Span name                  | Emitted by              | Attributes                                           |
+| -------------------------- | ----------------------- | ---------------------------------------------------- |
+| `xstate.nats.subscribe`    | `SUBJECT.SUBSCRIBE`     | `subject`                                            |
+| `xstate.nats.message`      | per received message    | `subject`, `payload.bytes`                           |
+| `xstate.nats.publish`      | `SUBJECT.PUBLISH`       | `subject`, `payload.bytes`                           |
+| `xstate.nats.request`      | `SUBJECT.REQUEST`       | `subject`, `payload.bytes`, `timeout.ms`             |
+| `xstate.nats.reconnect`    | NATS status loop        | `reconnect.type`                                     |
+| `xstate.nats.kv.watch`     | `KV.SUBSCRIBE`          | `bucket`, `key`                                      |
+| `xstate.nats.kv.entry`     | per KV watch entry      | `bucket`, `key`, `operation`                         |
+
+All error paths record exceptions on the active span, set span status to
+`ERROR`, and emit a named event (`xstate.nats.error` / `xstate.nats.kv.error`)
+with a truncated stack.
+
+### Enabling tracing
+
+`@opentelemetry/api` is a peer dependency — the consumer controls the installed
+version and registers the SDK. If no provider is registered all telemetry calls
+become no-ops. Minimal setup:
+
+```ts
+import { trace, propagation, context } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+
+const provider = new BasicTracerProvider({ spanProcessors: [/* your exporter */] })
+trace.setGlobalTracerProvider(provider)
+propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+
+const ctxMgr = new AsyncLocalStorageContextManager()
+ctxMgr.enable()
+context.setGlobalContextManager(ctxMgr)
+```
+
+### Context propagation
+
+Publish and request operations inject `traceparent` into the outgoing NATS
+headers; received messages extract the traceparent and parent their
+`xstate.nats.message` span on it. Downstream services that propagate the header
+appear as children of the originating publisher/requester span.
+
 ## Examples
 
 Check out the [React example](./examples/react-test/) for a complete working implementation.

--- a/README.md
+++ b/README.md
@@ -226,15 +226,15 @@ and request/reply replier.
 
 ### Emitted spans
 
-| Span name                  | Emitted by              | Attributes                                           |
-| -------------------------- | ----------------------- | ---------------------------------------------------- |
-| `xstate.nats.subscribe`    | `SUBJECT.SUBSCRIBE`     | `subject`                                            |
-| `xstate.nats.message`      | per received message    | `subject`, `payload.bytes`                           |
-| `xstate.nats.publish`      | `SUBJECT.PUBLISH`       | `subject`, `payload.bytes`                           |
-| `xstate.nats.request`      | `SUBJECT.REQUEST`       | `subject`, `payload.bytes`, `timeout.ms`             |
-| `xstate.nats.reconnect`    | NATS status loop        | `reconnect.type`                                     |
-| `xstate.nats.kv.watch`     | `KV.SUBSCRIBE`          | `bucket`, `key`                                      |
-| `xstate.nats.kv.entry`     | per KV watch entry      | `bucket`, `key`, `operation`                         |
+| Span name               | Emitted by           | Attributes                               |
+| ----------------------- | -------------------- | ---------------------------------------- |
+| `xstate.nats.subscribe` | `SUBJECT.SUBSCRIBE`  | `subject`                                |
+| `xstate.nats.message`   | per received message | `subject`, `payload.bytes`               |
+| `xstate.nats.publish`   | `SUBJECT.PUBLISH`    | `subject`, `payload.bytes`               |
+| `xstate.nats.request`   | `SUBJECT.REQUEST`    | `subject`, `payload.bytes`, `timeout.ms` |
+| `xstate.nats.reconnect` | NATS status loop     | `reconnect.type`                         |
+| `xstate.nats.kv.watch`  | `KV.SUBSCRIBE`       | `bucket`, `key`                          |
+| `xstate.nats.kv.entry`  | per KV watch entry   | `bucket`, `key`, `operation`             |
 
 All error paths record exceptions on the active span, set span status to
 `ERROR`, and emit a named event (`xstate.nats.error` / `xstate.nats.kv.error`)
@@ -252,7 +252,11 @@ import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-ho
 import { W3CTraceContextPropagator } from '@opentelemetry/core'
 import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-const provider = new BasicTracerProvider({ spanProcessors: [/* your exporter */] })
+const provider = new BasicTracerProvider({
+  spanProcessors: [
+    /* your exporter */
+  ],
+})
 trace.setGlobalTracerProvider(provider)
 propagation.setGlobalPropagator(new W3CTraceContextPropagator())
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jr200-labs/xstate-nats",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "XState machine for NATS",
   "license": "MIT",
   "author": "Jayshan Raghunandan",
@@ -48,8 +48,15 @@
     "@nats-io/obj": "^3.3.1",
     "xstate": "^5.30.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/context-async-hooks": "^2.7.0",
+    "@opentelemetry/core": "^2.7.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.0",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^2.7.0",
     "@opentelemetry/core": "^2.7.0",
     "@opentelemetry/sdk-trace-base": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
       '@opentelemetry/api':
-        specifier: ^1.9.1
+        specifier: ^1.9.0
         version: 1.9.1
       '@opentelemetry/context-async-hooks':
         specifier: ^2.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,18 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
@@ -53,7 +65,7 @@ importers:
         version: 8.58.2(eslint@10.2.1)(typescript@6.0.2)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@vitest/coverage-v8@4.1.4)(vite@8.0.8)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@vitest/coverage-v8@4.1.4)(vite@8.0.8)
 
 packages:
 
@@ -181,6 +193,38 @@ packages:
 
   '@nats-io/obj@3.3.1':
     resolution: {integrity: sha512-sGQbVdCE1TeAWyNT1o5ynPUo618J1d7gVtKnlbH+X/0hucEHTSYjqNB+6ZfGdVfQkoQISzjLsB7xvG7nqunPmg==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
@@ -1136,6 +1180,32 @@ snapshots:
       '@nats-io/nats-core': 3.3.1
       js-sha256: 0.11.1
 
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@oxc-project/types@0.124.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
@@ -1312,7 +1382,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/coverage-v8@4.1.4)(vite@8.0.8)
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@vitest/coverage-v8@4.1.4)(vite@8.0.8)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -1806,7 +1876,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.4(@vitest/coverage-v8@4.1.4)(vite@8.0.8):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@vitest/coverage-v8@4.1.4)(vite@8.0.8):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8)
@@ -1829,6 +1899,7 @@ snapshots:
       vite: 8.0.8
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw

--- a/src/actions/connection.ts
+++ b/src/actions/connection.ts
@@ -10,6 +10,7 @@ import {
 import { KvEntry } from '@nats-io/kv'
 import { type AuthConfig } from './types'
 import { sendParent } from 'xstate'
+import { withSpan } from '../telemetry'
 
 const makeAuthConfig = (auth?: AuthConfig) => {
   if (!auth) {
@@ -68,7 +69,16 @@ export const connectToNats = fromPromise(
             sendParent({ type: 'NATS_CONNECTION.DISCONNECTED', status })
             break
           case 'reconnect':
-            sendParent({ type: 'NATS_CONNECTION.RECONNECT', status })
+            // Per-event span so reconnect attempts become discoverable in
+            // the trace backend (searchable, durations, span counts).
+            withSpan(
+              'xstate.nats.reconnect',
+              'xstate.nats.error',
+              { 'reconnect.type': type },
+              () => {
+                sendParent({ type: 'NATS_CONNECTION.RECONNECT', status })
+              },
+            )
             break
           case 'error':
             sendParent({ type: 'NATS_CONNECTION.ERROR', status })
@@ -83,10 +93,24 @@ export const connectToNats = fromPromise(
             // console.debug('Received ping, pong sent automatically')
             break
           case 'forceReconnect':
-            sendParent({ type: 'NATS_CONNECTION.RECONNECT', status })
+            withSpan(
+              'xstate.nats.reconnect',
+              'xstate.nats.error',
+              { 'reconnect.type': type },
+              () => {
+                sendParent({ type: 'NATS_CONNECTION.RECONNECT', status })
+              },
+            )
             break
           case 'reconnecting':
-            sendParent({ type: 'NATS_CONNECTION.RECONNECTING', status })
+            withSpan(
+              'xstate.nats.reconnect',
+              'xstate.nats.error',
+              { 'reconnect.type': type },
+              () => {
+                sendParent({ type: 'NATS_CONNECTION.RECONNECTING', status })
+              },
+            )
             break
           case 'slowConsumer':
             console.debug('SLOW_CONSUMER', status)

--- a/src/actions/kv.ts
+++ b/src/actions/kv.ts
@@ -2,6 +2,7 @@ import { NatsConnection, QueuedIterator } from '@nats-io/nats-core'
 import { Kvm, KvWatchEntry, KvWatchOptions } from '@nats-io/kv'
 import { Pair } from '../utils'
 import { fromPromise } from 'xstate'
+import { recordError, withSpan } from '../telemetry'
 
 export class KvSubscriptionKey extends Pair<string, string> {}
 
@@ -54,25 +55,52 @@ export const kvConsolidateState = fromPromise(
           const kv = await input.kvm.open(config.bucket)
 
           const watchOptions = config as KvWatchOptions
-          const watcher = await kv.watch(watchOptions)
+          // Short span around the synchronous-ish watch() setup — the watcher
+          // iterator itself is long-lived, so each received entry gets its
+          // own span below rather than one indefinite parent.
+          const watcher = (await withSpan(
+            'xstate.nats.kv.watch',
+            'xstate.nats.kv.error',
+            { bucket: config.bucket, key: config.key },
+            () => kv.watch(watchOptions),
+          )) as QueuedIterator<KvWatchEntry>
 
           syncedState.set(kvKey, watcher)
           ;(async () => {
             try {
               for await (const e of watcher) {
                 if (e.operation !== 'DEL') {
-                  let parsedValue
-                  try {
-                    parsedValue = JSON.parse(e.string())
-                  } catch {
-                    parsedValue = e.string()
-                  }
+                  await withSpan(
+                    'xstate.nats.kv.entry',
+                    'xstate.nats.kv.error',
+                    {
+                      bucket: config.bucket,
+                      key: config.key,
+                      operation: e.operation,
+                    },
+                    (span) => {
+                      let parsedValue
+                      try {
+                        parsedValue = JSON.parse(e.string())
+                      } catch {
+                        parsedValue = e.string()
+                      }
 
-                  config.callback({
-                    bucket: config.bucket,
-                    key: config.key,
-                    value: parsedValue,
-                  })
+                      try {
+                        config.callback({
+                          bucket: config.bucket,
+                          key: config.key,
+                          value: parsedValue,
+                        })
+                      } catch (callbackError) {
+                        recordError(span, 'xstate.nats.kv.error', callbackError)
+                        console.error(
+                          `KV_SUBSCRIBE (connected): Callback error for ${kvKey}:`,
+                          callbackError,
+                        )
+                      }
+                    },
+                  )
                 }
               }
             } catch (error) {

--- a/src/actions/subject.telemetry.test.ts
+++ b/src/actions/subject.telemetry.test.ts
@@ -120,14 +120,12 @@ describe('subject telemetry', () => {
     })
 
     await vi.waitFor(() => {
-      expect(harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.request')).toBe(
-        true,
-      )
+      expect(
+        harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.request'),
+      ).toBe(true)
     })
 
-    const req = harness.exporter
-      .getFinishedSpans()
-      .find((s) => s.name === 'xstate.nats.request')!
+    const req = harness.exporter.getFinishedSpans().find((s) => s.name === 'xstate.nats.request')!
     expect(req.attributes.subject).toBe('t.req')
     expect(req.attributes['timeout.ms']).toBe(2500)
   })
@@ -187,9 +185,9 @@ describe('subject telemetry', () => {
 
     await iterDone
     await vi.waitFor(() => {
-      expect(harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.message')).toBe(
-        true,
-      )
+      expect(
+        harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.message'),
+      ).toBe(true)
     })
 
     const msgSpan = harness.exporter

--- a/src/actions/subject.telemetry.test.ts
+++ b/src/actions/subject.telemetry.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpanStatusCode } from '@opentelemetry/api'
+import { headers as natsHeaders } from '@nats-io/nats-core'
+import { setupInMemoryTracer, type OtelTestHarness } from '../../test/otel-setup'
+import { subjectConsolidateState, subjectPublish, subjectRequest } from './subject'
+import type { SubjectSubscriptionConfig } from './subject'
+
+vi.mock('./connection', () => ({
+  parseNatsResult: vi.fn((msg: any) => {
+    if (!msg) return null
+    try {
+      return msg.json()
+    } catch {
+      return msg.string()
+    }
+  }),
+}))
+
+function createMockConnection() {
+  return {
+    subscribe: vi.fn(),
+    request: vi.fn(),
+    publish: vi.fn(),
+  } as any
+}
+
+describe('subject telemetry', () => {
+  let harness: OtelTestHarness
+
+  beforeEach(() => {
+    harness = setupInMemoryTracer()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    harness.teardown()
+    vi.restoreAllMocks()
+  })
+
+  it('emits xstate.nats.subscribe span when adding a subscription', () => {
+    const connection = createMockConnection()
+    connection.subscribe.mockReturnValue({
+      unsubscribe: vi.fn(),
+      [Symbol.asyncIterator]: () => ({ next: () => new Promise(() => {}) }),
+    })
+
+    const target = new Map<string, SubjectSubscriptionConfig>([
+      ['t.sub', { subject: 't.sub', callback: vi.fn() }],
+    ])
+
+    subjectConsolidateState({
+      input: { connection, currentSubscriptions: new Map(), targetSubscriptions: target },
+    })
+
+    const spans = harness.exporter.getFinishedSpans()
+    const sub = spans.find((s) => s.name === 'xstate.nats.subscribe')
+    expect(sub).toBeDefined()
+    expect(sub!.attributes.subject).toBe('t.sub')
+    expect(sub!.status.code).not.toBe(SpanStatusCode.ERROR)
+  })
+
+  it('emits xstate.nats.publish span with payload bytes', () => {
+    const connection = createMockConnection()
+    subjectPublish({
+      input: { connection, subject: 't.pub', payload: 'hello' },
+    })
+
+    const spans = harness.exporter.getFinishedSpans()
+    const pub = spans.find((s) => s.name === 'xstate.nats.publish')
+    expect(pub).toBeDefined()
+    expect(pub!.attributes.subject).toBe('t.pub')
+    expect(pub!.attributes['payload.bytes']).toBe(5)
+  })
+
+  it('injects traceparent into publish headers', () => {
+    const connection = createMockConnection()
+    subjectPublish({
+      input: { connection, subject: 't.pub', payload: 'x' },
+    })
+
+    const call = connection.publish.mock.calls[0]
+    const opts = call[2]
+    expect(opts.headers).toBeDefined()
+    // traceparent header is set by W3CTraceContextPropagator
+    expect(opts.headers.get('traceparent')).toBeTruthy()
+  })
+
+  it('records error on publish span when connection.publish throws', () => {
+    const connection = createMockConnection()
+    connection.publish.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    subjectPublish({
+      input: { connection, subject: 't.fail', payload: 'x' },
+    })
+
+    const spans = harness.exporter.getFinishedSpans()
+    const pub = spans.find((s) => s.name === 'xstate.nats.publish')
+    expect(pub).toBeDefined()
+    expect(pub!.status.code).toBe(SpanStatusCode.ERROR)
+    expect(pub!.events.some((e) => e.name === 'xstate.nats.error')).toBe(true)
+  })
+
+  it('emits xstate.nats.request span with request attrs', async () => {
+    const connection = createMockConnection()
+    connection.request.mockResolvedValue({
+      json: () => ({ ok: true }),
+      string: () => '{"ok":true}',
+    })
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 't.req',
+        payload: 'x',
+        opts: { timeout: 2500 } as any,
+        callback: vi.fn(),
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.request')).toBe(
+        true,
+      )
+    })
+
+    const req = harness.exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'xstate.nats.request')!
+    expect(req.attributes.subject).toBe('t.req')
+    expect(req.attributes['timeout.ms']).toBe(2500)
+  })
+
+  it('records error on request span when connection.request rejects', async () => {
+    const connection = createMockConnection()
+    connection.request.mockRejectedValue(new Error('nope'))
+
+    subjectRequest({
+      input: { connection, subject: 't.req', payload: 'x', callback: vi.fn() },
+    })
+
+    await vi.waitFor(() => {
+      const req = harness.exporter.getFinishedSpans().find((s) => s.name === 'xstate.nats.request')
+      expect(req?.status.code).toBe(SpanStatusCode.ERROR)
+    })
+  })
+
+  it('parents per-message span on extracted traceparent', async () => {
+    const connection = createMockConnection()
+    // Craft a headers object containing a known traceparent so the extractor
+    // has something to parent on.
+    const incomingHdrs = natsHeaders()
+    incomingHdrs.set('traceparent', '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01')
+
+    let resolveIter: () => void
+    const iterDone = new Promise<void>((r) => (resolveIter = r))
+    let delivered = false
+    connection.subscribe.mockReturnValue({
+      unsubscribe: vi.fn(),
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          if (!delivered) {
+            delivered = true
+            return Promise.resolve({
+              value: {
+                headers: incomingHdrs,
+                json: () => ({ hi: 1 }),
+                string: () => '{"hi":1}',
+                data: new Uint8Array([1, 2, 3]),
+              },
+              done: false,
+            })
+          }
+          resolveIter!()
+          return new Promise(() => {})
+        },
+      }),
+    })
+
+    const target = new Map<string, SubjectSubscriptionConfig>([
+      ['t.msg', { subject: 't.msg', callback: vi.fn() }],
+    ])
+    subjectConsolidateState({
+      input: { connection, currentSubscriptions: new Map(), targetSubscriptions: target },
+    })
+
+    await iterDone
+    await vi.waitFor(() => {
+      expect(harness.exporter.getFinishedSpans().some((s) => s.name === 'xstate.nats.message')).toBe(
+        true,
+      )
+    })
+
+    const msgSpan = harness.exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'xstate.nats.message')!
+    expect(msgSpan.spanContext().traceId).toBe('0af7651916cd43dd8448eb211c80319c')
+    expect(msgSpan.attributes.subject).toBe('t.msg')
+  })
+})

--- a/src/actions/subject.test.ts
+++ b/src/actions/subject.test.ts
@@ -332,7 +332,11 @@ describe('subjectRequest', () => {
       expect(callback).toHaveBeenCalled()
     })
 
-    expect(connection.request).toHaveBeenCalledWith('test.request', { data: 1 }, { timeout: 5000 })
+    expect(connection.request).toHaveBeenCalledWith(
+      'test.request',
+      { data: 1 },
+      expect.objectContaining({ timeout: 5000 }),
+    )
   })
 
   it('should handle request errors', async () => {
@@ -387,7 +391,11 @@ describe('subjectPublish', () => {
       },
     })
 
-    expect(connection.publish).toHaveBeenCalledWith('test.publish', { msg: 'hello' }, undefined)
+    expect(connection.publish).toHaveBeenCalledWith(
+      'test.publish',
+      { msg: 'hello' },
+      expect.objectContaining({ headers: expect.anything() }),
+    )
   })
 
   it('should call onPublishResult with ok on success', () => {
@@ -419,7 +427,11 @@ describe('subjectPublish', () => {
       },
     })
 
-    expect(connection.publish).toHaveBeenCalledWith('test.publish', 'data', options)
+    expect(connection.publish).toHaveBeenCalledWith(
+      'test.publish',
+      'data',
+      expect.objectContaining({ headers: expect.anything() }),
+    )
   })
 
   it('should call onPublishResult with error on failure', () => {

--- a/src/actions/subject.ts
+++ b/src/actions/subject.ts
@@ -7,6 +7,12 @@ import {
   SubscriptionOptions,
 } from '@nats-io/nats-core'
 import { parseNatsResult } from './connection'
+import {
+  extractContextFromHeaders,
+  injectContextIntoHeaders,
+  recordError,
+  withSpan,
+} from '../telemetry'
 
 export type SubjectSubscriptionConfig = {
   subject: string
@@ -46,17 +52,44 @@ export const subjectConsolidateState = ({
   for (const [subject, subscriptionConfig] of targetSubscriptions) {
     if (!currentSubscriptions.has(subject)) {
       try {
-        const sub = connection.subscribe(subject, subscriptionConfig.opts)
+        // Short span around the synchronous subscribe() call. The iterator
+        // below is long-lived; we don't span its whole lifetime (indefinite
+        // spans are anti-pattern in most tracing backends).
+        const sub = withSpan(
+          'xstate.nats.subscribe',
+          'xstate.nats.error',
+          { subject },
+          () => connection.subscribe(subject, subscriptionConfig.opts),
+        ) as Subscription
 
-        // Set up the message handler
+        // Message loop: each received message starts its own span, parented
+        // on the traceparent extracted from the message headers (OTel
+        // messaging semconv). If the publisher did not propagate context the
+        // extracted context falls back to the ambient one, so the span
+        // simply becomes a root.
         ;(async () => {
           try {
             for await (const msg of sub) {
-              try {
-                subscriptionConfig?.callback(parseNatsResult(msg))
-              } catch (callbackError) {
-                console.error(`Callback error for subject "${subject}"`, callbackError)
-              }
+              const parentCtx = extractContextFromHeaders((msg as Msg).headers)
+              await withSpan(
+                'xstate.nats.message',
+                'xstate.nats.error',
+                {
+                  subject,
+                  'payload.bytes': (msg as Msg).data?.length,
+                },
+                (span) => {
+                  try {
+                    subscriptionConfig?.callback(parseNatsResult(msg))
+                  } catch (callbackError) {
+                    // Record on span AND preserve the existing console.error
+                    // so consumers without OTel still see the failure.
+                    recordError(span, 'xstate.nats.error', callbackError)
+                    console.error(`Callback error for subject "${subject}"`, callbackError)
+                  }
+                },
+                parentCtx,
+              )
             }
           } catch (iteratorError) {
             console.error(`Iterator error for subject "${subject}"`, iteratorError)
@@ -91,14 +124,44 @@ export const subjectRequest = ({
     throw new Error('NATS connection is not available')
   }
 
-  connection
-    .request(subject, payload, opts)
-    .then((msg: Msg) => {
-      callback(parseNatsResult(msg))
-    })
-    .catch((err) => {
-      console.error(`RequestReply error for subject "${subject}"`, err)
-    })
+  const payloadBytes =
+    payload instanceof Uint8Array
+      ? payload.byteLength
+      : typeof payload === 'string'
+        ? payload.length
+        : undefined
+
+  void withSpan(
+    'xstate.nats.request',
+    'xstate.nats.error',
+    {
+      subject,
+      'payload.bytes': payloadBytes,
+      'timeout.ms': opts?.timeout,
+    },
+    (span) => {
+      // Inject INSIDE the span so the replying service parents its handler
+      // span on this request span (not on an ambient context). RequestOptions
+      // declares `timeout` as required but nats-core only enforces it when
+      // opts is provided; cast preserves the "no opts = use conn default"
+      // contract.
+      const headers = injectContextIntoHeaders(opts?.headers)
+      const requestOpts = (opts ? { ...opts, headers } : { headers }) as RequestOptions
+
+      return connection
+        .request(subject, payload, requestOpts)
+        .then((msg: Msg) => {
+          callback(parseNatsResult(msg))
+        })
+        .catch((err) => {
+          // Record on span manually so we can swallow the rejection here —
+          // the original fire-and-forget API didn't propagate request errors
+          // to callers and changing that now would be a breaking behaviour.
+          recordError(span, 'xstate.nats.error', err)
+          console.error(`RequestReply error for subject "${subject}"`, err)
+        })
+    },
+  )
 }
 
 export const subjectPublish = ({
@@ -117,8 +180,26 @@ export const subjectPublish = ({
     throw new Error('NATS connection is not available')
   }
 
+  const payloadBytes =
+    payload instanceof Uint8Array
+      ? payload.byteLength
+      : typeof payload === 'string'
+        ? payload.length
+        : undefined
+
   try {
-    connection.publish(subject, payload, options)
+    withSpan(
+      'xstate.nats.publish',
+      'xstate.nats.error',
+      { subject, 'payload.bytes': payloadBytes },
+      () => {
+        // Inject INSIDE the span so downstream subscribers see THIS span as
+        // parent instead of whatever was ambient before publish.
+        const headers = injectContextIntoHeaders(options?.headers)
+        const publishOpts: PublishOptions = { ...(options ?? {}), headers }
+        connection.publish(subject, payload, publishOpts)
+      },
+    )
     onPublishResult?.({ ok: true })
   } catch (callbackError) {
     console.error(`Publish callback error for subject "${subject}"`, callbackError)

--- a/src/actions/subject.ts
+++ b/src/actions/subject.ts
@@ -55,11 +55,8 @@ export const subjectConsolidateState = ({
         // Short span around the synchronous subscribe() call. The iterator
         // below is long-lived; we don't span its whole lifetime (indefinite
         // spans are anti-pattern in most tracing backends).
-        const sub = withSpan(
-          'xstate.nats.subscribe',
-          'xstate.nats.error',
-          { subject },
-          () => connection.subscribe(subject, subscriptionConfig.opts),
+        const sub = withSpan('xstate.nats.subscribe', 'xstate.nats.error', { subject }, () =>
+          connection.subscribe(subject, subscriptionConfig.opts),
         ) as Subscription
 
         // Message loop: each received message starts its own span, parented

--- a/src/machines/kv.test.ts
+++ b/src/machines/kv.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createActor, fromPromise, sendTo, setup, assign } from 'xstate'
 import { kvManagerLogic } from './kv'
 
-vi.mock('@nats-io/nats-core', () => ({
-  wsconnect: vi.fn(),
-}))
+vi.mock('@nats-io/nats-core', async () => {
+  const actual = await vi.importActual<typeof import('@nats-io/nats-core')>('@nats-io/nats-core')
+  return {
+    ...actual,
+    wsconnect: vi.fn(),
+  }
+})
 
 // We'll set up specific Kvm mock behavior per test
 const mockKvStore = {

--- a/src/machines/root.test.ts
+++ b/src/machines/root.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createActor, fromPromise, createMachine, sendParent } from 'xstate'
 import { natsMachine } from './root'
 
-vi.mock('@nats-io/nats-core', () => ({
-  wsconnect: vi.fn(),
-  credsAuthenticator: vi.fn(),
-}))
+vi.mock('@nats-io/nats-core', async () => {
+  const actual = await vi.importActual<typeof import('@nats-io/nats-core')>('@nats-io/nats-core')
+  return {
+    ...actual,
+    wsconnect: vi.fn(),
+    credsAuthenticator: vi.fn(),
+  }
+})
 
 vi.mock('@nats-io/kv', () => ({
   Kvm: vi.fn().mockImplementation(() => ({})),

--- a/src/machines/subject.test.ts
+++ b/src/machines/subject.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createActor, createMachine, assign, fromPromise, sendTo, setup } from 'xstate'
 import { subjectManagerLogic } from './subject'
 
-vi.mock('@nats-io/nats-core', () => ({
-  wsconnect: vi.fn(),
-}))
+vi.mock('@nats-io/nats-core', async () => {
+  const actual = await vi.importActual<typeof import('@nats-io/nats-core')>('@nats-io/nats-core')
+  return {
+    ...actual,
+    wsconnect: vi.fn(),
+  }
+})
 
 function createMockConnection() {
   return {
@@ -195,7 +199,11 @@ describe('subjectManagerLogic', () => {
       payload: { msg: 'hello' },
     })
 
-    expect(connection.publish).toHaveBeenCalledWith('test.pub', { msg: 'hello' }, undefined)
+    expect(connection.publish).toHaveBeenCalledWith(
+      'test.pub',
+      { msg: 'hello' },
+      expect.objectContaining({ headers: expect.anything() }),
+    )
     parentActor.stop()
   })
 
@@ -214,7 +222,11 @@ describe('subjectManagerLogic', () => {
       callback,
     })
 
-    expect(connection.request).toHaveBeenCalledWith('test.req', { data: 1 }, undefined)
+    expect(connection.request).toHaveBeenCalledWith(
+      'test.req',
+      { data: 1 },
+      expect.objectContaining({ headers: expect.anything() }),
+    )
     parentActor.stop()
   })
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -14,12 +14,7 @@
 //     the per-message span so cross-process traces nest automatically.
 
 import type { Context, Span, Tracer } from '@opentelemetry/api'
-import {
-  context as otelContext,
-  propagation,
-  SpanStatusCode,
-  trace,
-} from '@opentelemetry/api'
+import { context as otelContext, propagation, SpanStatusCode, trace } from '@opentelemetry/api'
 import type { MsgHdrs } from '@nats-io/nats-core'
 import { headers as natsHeaders } from '@nats-io/nats-core'
 import pkg from '../package.json' with { type: 'json' }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,150 @@
+// OpenTelemetry helpers scoped to this package.
+//
+// `@opentelemetry/api` is declared as a peer dependency so the consumer
+// controls the installed version. If the consumer never registers a
+// TracerProvider / TextMapPropagator, every call here becomes a no-op.
+//
+// Design choices:
+//   - Single module-level tracer, named and versioned from package.json.
+//   - `withSpan` wraps the common try/catch/recordException/setStatus pattern
+//     so call sites stay readable.
+//   - `injectContextIntoHeaders` / `extractContextFromHeaders` bridge the
+//     OTel propagation API onto NATS `MsgHdrs`. Outgoing messages carry the
+//     active traceparent; incoming messages become the active context for
+//     the per-message span so cross-process traces nest automatically.
+
+import type { Context, Span, Tracer } from '@opentelemetry/api'
+import {
+  context as otelContext,
+  propagation,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api'
+import type { MsgHdrs } from '@nats-io/nats-core'
+import { headers as natsHeaders } from '@nats-io/nats-core'
+import pkg from '../package.json' with { type: 'json' }
+
+const TRACER_NAME = '@jr200-labs/xstate-nats'
+
+// Do not cache — `trace.getTracer` already returns a lightweight ProxyTracer,
+// and caching across global-provider swaps (e.g. test teardown / re-register)
+// would pin the delegate to a retired provider and silently lose spans.
+export function getTracer(): Tracer {
+  return trace.getTracer(TRACER_NAME, pkg.version)
+}
+
+// Truncate the stack trace before attaching it to a span event. Some backends
+// (and the wire format itself) perform poorly with arbitrarily long strings;
+// the first ~1KB is almost always enough to identify the site.
+const MAX_STACK_LEN = 1024
+
+function truncateStack(err: unknown): string | undefined {
+  if (!(err instanceof Error) || !err.stack) return undefined
+  return err.stack.length > MAX_STACK_LEN
+    ? err.stack.slice(0, MAX_STACK_LEN) + '...(truncated)'
+    : err.stack
+}
+
+/**
+ * Record an error on a span using the OTel canonical pattern:
+ * recordException + ERROR status + a named event with the truncated stack.
+ */
+export function recordError(span: Span, errorEventName: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err)
+  if (err instanceof Error) {
+    span.recordException(err)
+  }
+  span.setStatus({ code: SpanStatusCode.ERROR, message })
+  const stack = truncateStack(err)
+  span.addEvent(errorEventName, stack ? { stack } : undefined)
+}
+
+/**
+ * Run `fn` inside an active span. On synchronous throw or async rejection the
+ * error is recorded, the span status is set to ERROR, and the error is
+ * re-thrown (callers keep their existing error-handling semantics).
+ */
+export function withSpan<T>(
+  name: string,
+  errorEventName: string,
+  attributes: Record<string, string | number | boolean | undefined>,
+  fn: (span: Span) => T | Promise<T>,
+  parentContext?: Context,
+): T | Promise<T> {
+  const tracer = getTracer()
+  const sanitized = sanitizeAttributes(attributes)
+  const ctx = parentContext ?? otelContext.active()
+  return tracer.startActiveSpan(name, { attributes: sanitized }, ctx, (span) => {
+    try {
+      const result = fn(span)
+      if (result && typeof (result as Promise<T>).then === 'function') {
+        return (result as Promise<T>).then(
+          (value) => {
+            span.end()
+            return value
+          },
+          (err: unknown) => {
+            recordError(span, errorEventName, err)
+            span.end()
+            throw err
+          },
+        ) as unknown as T
+      }
+      span.end()
+      return result
+    } catch (err) {
+      recordError(span, errorEventName, err)
+      span.end()
+      throw err
+    }
+  })
+}
+
+// OTel attributes cannot be `undefined`; strip those so call sites can pass
+// optional values without a pre-filter.
+function sanitizeAttributes(
+  attrs: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {}
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined) out[k] = v
+  }
+  return out
+}
+
+// Carrier adapters: NATS `MsgHdrs` exposes `.set(k, v)`, `.get(k)`, `.keys()`
+// which maps cleanly to the OTel TextMapSetter / TextMapGetter interface.
+const natsHeaderSetter = {
+  set: (carrier: MsgHdrs, key: string, value: string) => {
+    carrier.set(key, value)
+  },
+}
+
+const natsHeaderGetter = {
+  get: (carrier: MsgHdrs | undefined, key: string): string | undefined => {
+    const v = carrier?.get(key)
+    return v || undefined
+  },
+  keys: (carrier: MsgHdrs | undefined): string[] => carrier?.keys() ?? [],
+}
+
+/**
+ * Inject the active OTel context into a NATS headers object, creating one if
+ * none was supplied. Returns the headers object so the caller can pass it to
+ * `connection.publish` / `connection.request` via the `opts.headers` field.
+ */
+export function injectContextIntoHeaders(existing?: MsgHdrs): MsgHdrs {
+  const hdrs = existing ?? natsHeaders()
+  propagation.inject(otelContext.active(), hdrs, natsHeaderSetter)
+  return hdrs
+}
+
+/**
+ * Extract a parent OTel context from an incoming NATS message's headers. When
+ * no traceparent is present the returned context is whatever was already
+ * active — callers can use it as the parent for a new span without a branch.
+ */
+export function extractContextFromHeaders(hdrs: MsgHdrs | undefined): Context {
+  if (!hdrs) return otelContext.active()
+  return propagation.extract(otelContext.active(), hdrs, natsHeaderGetter)
+}

--- a/test/otel-setup.ts
+++ b/test/otel-setup.ts
@@ -1,0 +1,52 @@
+// Shared OpenTelemetry test harness.
+//
+// Each test registers an in-memory exporter so span emission can be asserted
+// without a real backend. The global TracerProvider / Propagator are reset
+// between tests to keep cases isolated.
+
+import { context, propagation, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+
+export interface OtelTestHarness {
+  exporter: InMemorySpanExporter
+  provider: BasicTracerProvider
+  /** Drop buffered spans without tearing down the provider. */
+  reset: () => void
+  /** Unregister provider + propagator. Call in afterEach. */
+  teardown: () => void
+}
+
+// sdk-trace-base v2 removed `provider.register()`; wire up the global tracer
+// provider, propagator, and context manager directly through the API package.
+// Without the context manager, `startActiveSpan` would run the callback but
+// never attach the span to `context.active()` — which breaks propagation.
+export function setupInMemoryTracer(): OtelTestHarness {
+  const exporter = new InMemorySpanExporter()
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  const ctxMgr = new AsyncLocalStorageContextManager()
+  ctxMgr.enable()
+  context.setGlobalContextManager(ctxMgr)
+  trace.setGlobalTracerProvider(provider)
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+
+  return {
+    exporter,
+    provider,
+    reset: () => exporter.reset(),
+    teardown: () => {
+      trace.disable()
+      propagation.disable()
+      context.disable()
+      ctxMgr.disable()
+      void provider.shutdown()
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Emit OTel spans for NATS subscribe/message/publish/request/reconnect and KV watch/entry operations
- Propagate W3C trace context through NATS headers so publisher, subscriber, and replier nest in a single trace
- Add `@opentelemetry/api` as a **peer dependency** so the consumer pins the version and the singleton resolves to a single copy

## Spans emitted

| Span | Trigger | Attrs |
| - | - | - |
| `xstate.nats.subscribe` | `SUBJECT.SUBSCRIBE` | `subject` |
| `xstate.nats.message` | per received message | `subject`, `payload.bytes` |
| `xstate.nats.publish` | `SUBJECT.PUBLISH` | `subject`, `payload.bytes` |
| `xstate.nats.request` | `SUBJECT.REQUEST` | `subject`, `payload.bytes`, `timeout.ms` |
| `xstate.nats.reconnect` | NATS status loop | `reconnect.type` |
| `xstate.nats.kv.watch` | `KV.SUBSCRIBE` | `bucket`, `key` |
| `xstate.nats.kv.entry` | per KV watch entry | `bucket`, `key`, `operation` |

All error paths record exceptions, set span status to `ERROR`, and emit a named error event with truncated stack.

## Design notes

- `traceparent` is injected **inside** the span scope so downstream handlers parent on the originating publish/request span (not on ambient context).
- `subjectRequest` error path records the error on the span but continues to swallow the rejection — preserves the prior fire-and-forget contract.
- No cached tracer: `trace.getTracer` already returns a lightweight ProxyTracer; caching across global-provider swaps pins the delegate to a retired provider.

## Test plan

- [x] All 105 existing tests pass (mocks updated to spread `importActual` so new `headers` import resolves)
- [x] New `subject.telemetry.test.ts` asserts span emission, attrs, error status, and end-to-end traceparent round-trip via `InMemorySpanExporter` harness in `test/otel-setup.ts`
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm lint` clean (0 errors; pre-existing warnings only)

Refs JRL-11