### PR TITLE
fix: report subject request failures

### DIFF
--- a/src/actions/subject.test.ts
+++ b/src/actions/subject.test.ts
@@ -317,6 +317,7 @@ describe('subjectRequest', () => {
     connection.request.mockResolvedValue(mockMsg)
 
     const callback = vi.fn()
+    const onRequestResult = vi.fn()
     subjectRequest({
       input: {
         connection,
@@ -324,6 +325,7 @@ describe('subjectRequest', () => {
         payload: { data: 1 },
         opts: { timeout: 5000 } as any,
         callback,
+        onRequestResult,
       },
     })
 
@@ -331,6 +333,7 @@ describe('subjectRequest', () => {
     await vi.waitFor(() => {
       expect(callback).toHaveBeenCalled()
     })
+    expect(onRequestResult).toHaveBeenCalledWith({ ok: true })
 
     expect(connection.request).toHaveBeenCalledWith(
       'test.request',
@@ -344,6 +347,7 @@ describe('subjectRequest', () => {
     connection.request.mockRejectedValue(new Error('request failed'))
 
     const callback = vi.fn()
+    const onRequestResult = vi.fn()
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     subjectRequest({
@@ -352,6 +356,7 @@ describe('subjectRequest', () => {
         subject: 'test.fail',
         payload: {},
         callback,
+        onRequestResult,
       },
     })
 
@@ -364,6 +369,7 @@ describe('subjectRequest', () => {
 
     consoleSpy.mockRestore()
     expect(callback).not.toHaveBeenCalled()
+    expect(onRequestResult).toHaveBeenCalledWith({ ok: false, error: expect.any(Error) })
   })
 })
 

--- a/src/actions/subject.ts
+++ b/src/actions/subject.ts
@@ -20,6 +20,8 @@ export type SubjectSubscriptionConfig = {
   opts?: SubscriptionOptions
 }
 
+export type RequestResult = { ok: true } | { ok: false; error: Error }
+
 export const subjectConsolidateState = ({
   input,
 }: {
@@ -114,9 +116,10 @@ export const subjectRequest = ({
     payload: any
     opts?: RequestOptions
     callback: (data: any) => void
+    onRequestResult?: (result: RequestResult) => void
   }
 }) => {
-  const { connection, subject, payload, opts, callback } = input
+  const { connection, subject, payload, opts, callback, onRequestResult } = input
   if (!connection) {
     throw new Error('NATS connection is not available')
   }
@@ -149,6 +152,7 @@ export const subjectRequest = ({
         .request(subject, payload, requestOpts)
         .then((msg: Msg) => {
           callback(parseNatsResult(msg))
+          onRequestResult?.({ ok: true })
         })
         .catch((err) => {
           // Record on span manually so we can swallow the rejection here —
@@ -156,6 +160,7 @@ export const subjectRequest = ({
           // to callers and changing that now would be a breaking behaviour.
           recordError(span, 'xstate.nats.error', err)
           console.error(`RequestReply error for subject "${subject}"`, err)
+          onRequestResult?.({ ok: false, error: err as Error })
         })
     },
   )

--- a/src/machines/subject.ts
+++ b/src/machines/subject.ts
@@ -1,6 +1,7 @@
 import { Subscription, PublishOptions, NatsConnection, RequestOptions } from '@nats-io/nats-core'
 import { assign, sendParent, setup } from 'xstate'
 import {
+  RequestResult,
   SubjectSubscriptionConfig,
   subjectConsolidateState,
   subjectRequest,
@@ -28,6 +29,7 @@ export type ExternalEvents =
       payload: any
       opts?: RequestOptions
       callback: (data: any) => void
+      onRequestResult?: (result: RequestResult) => void
     }
   | { type: 'SUBJECT.SUBSCRIBE'; config: SubjectSubscriptionConfig }
   | { type: 'SUBJECT.UNSUBSCRIBE'; subject: string }
@@ -138,6 +140,7 @@ export const subjectManagerLogic = setup({
                 payload: event.payload,
                 opts: event.opts,
                 callback: event.callback,
+                onRequestResult: event.onRequestResult,
               },
             })
             return {}


### PR DESCRIPTION
## Summary
- Add an optional onRequestResult callback to SUBJECT.REQUEST.
- Report successful and failed request-reply outcomes to callers without changing the existing fire-and-forget behavior.
- Preserve existing console/telemetry error handling.

## Testing
- pnpm build
- pnpm test src/actions/subject.test.ts
- pre-commit hook: prettier, lint, full pnpm test