### PR TITLE
chore: sync shared npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -29,6 +29,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   configure:


### PR DESCRIPTION
## Summary
- sync publish-npm-package.yaml from shared-v0.1.3
- add id-token: write so npm trusted publishing can run without the skipped OIDC warning

## Verification
- ./scripts/sync-shared
- ./scripts/sync-shared --check