### PR TITLE
chore: sync token-only npm publishing workflow

### DIFF
--- a/.github/.shared-config.yaml
+++ b/.github/.shared-config.yaml
@@ -1,4 +1,4 @@
-ref: shared-v0.1.3
+ref: shared-v0.1.5
 workflows:
   - hygiene
   - node

--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   configure:


### PR DESCRIPTION
## Summary
- bump shared workflow pin to shared-v0.1.5
- sync publish-npm-package back to token-only auth using NPMJS_API_TOKEN
- sync sync-shared-drift app-token fix for future workflow-file repair PRs

## Verification
- ./scripts/sync-shared
- ./scripts/sync-shared --check