### PR TITLE
chore: sync shared drift workflow

### DIFF
--- a/.github/workflows/sync-shared-drift.yaml
+++ b/.github/workflows/sync-shared-drift.yaml
@@ -1,5 +1,6 @@
 # GENERATED/SHARED WORKFLOW: copied into consuming repos by sync-shared.
-# Do not edit in consuming repos; change jr200-labs/github-action-templates and sync.
+# DO NOT MANUALLY MODIFY THIS FILE IN A CONSUMER REPO.
+# Always edit the source workflow in jr200-labs/github-action-templates, then sync.
 name: sync-shared-drift
 
 # If the shared workflow drift check fails, repair the default branch by
@@ -25,9 +26,18 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ vars.INTEGRATION_CLIENT_ID }}
+          private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync shared workflow callers
         run: ./scripts/sync-shared
@@ -35,6 +45,7 @@ jobs:
       - name: Create drift repair PR
         uses: peter-evans/create-pull-request@v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: chore/sync-shared-workflows
           delete-branch: true
           commit-message: "chore: sync shared workflows"


### PR DESCRIPTION
Summary:
- sync generated .github/workflows/sync-shared-drift.yaml from GAT shared-v0.1.6
- add the integration app token checkout/create-pull-request path
- include the stronger generated-workflow warning from GAT

Why:
The failing sync-shared-drift run is using the old generated workflow. It can detect the drift, but cannot push a PR that updates a workflow file because it does not yet use the integration app token with workflow permissions.

This is a one-time generated sync from the GAT source, not a manual source-repo workflow edit.

Test:
- ./scripts/sync-shared --check