### PR TITLE
fix: handle nats reconfiguration lifecycle

### DIFF
--- a/src/machines/root.test.ts
+++ b/src/machines/root.test.ts
@@ -64,6 +64,17 @@ const mockConnection = {
   }),
 } as any
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
 function createTestMachine() {
   return natsMachine.provide({
     actors: {
@@ -230,6 +241,32 @@ describe('natsMachine', () => {
     actor.stop()
   })
 
+  it('should reconfigure from closed state', async () => {
+    const actor = createActor(createTestMachine())
+    actor.start()
+    configureAndConnect(actor)
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+    actor.send({ type: 'DISCONNECT' })
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('closed')
+    })
+
+    actor.send({
+      type: 'CONFIGURE',
+      config: { opts: { debug: true, servers: ['ws://localhost:4223'] }, maxRetries: 5 },
+    })
+
+    expect(actor.getSnapshot().value).toBe('configured')
+    expect(actor.getSnapshot().context.natsConfig).toEqual({
+      opts: { debug: true, servers: ['ws://localhost:4223'] },
+      maxRetries: 5,
+    })
+    actor.stop()
+  })
+
   it('should reset from closed state', async () => {
     const actor = createActor(createTestMachine())
     actor.start()
@@ -290,6 +327,121 @@ describe('natsMachine', () => {
       expect(actor.getSnapshot().value).toBe('error')
     })
     expect(actor.getSnapshot().context.error).toBe(disconnectError)
+    actor.stop()
+  })
+
+  it('should reconfigure from error state', async () => {
+    const failMachine = natsMachine.provide({
+      actors: {
+        connectToNats: fromPromise(async () => {
+          throw new Error('fail')
+        }),
+        disconnectNats: fromPromise(async () => {}),
+        subject: mockSubjectMachine,
+        kv: mockKvMachine,
+      },
+    })
+
+    const actor = createActor(failMachine)
+    actor.start()
+    configureAndConnect(actor)
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('error')
+    })
+
+    actor.send({
+      type: 'CONFIGURE',
+      config: { opts: { debug: true, servers: ['ws://localhost:4224'] }, maxRetries: 1 },
+    })
+
+    expect(actor.getSnapshot().value).toBe('configured')
+    expect(actor.getSnapshot().context.error).toBeUndefined()
+    expect(actor.getSnapshot().context.natsConfig).toEqual({
+      opts: { debug: true, servers: ['ws://localhost:4224'] },
+      maxRetries: 1,
+    })
+    actor.stop()
+  })
+
+  it('should reconnect when configured while connected', async () => {
+    const connectInputs: any[] = []
+    const machine = natsMachine.provide({
+      actors: {
+        connectToNats: fromPromise(async ({ input }) => {
+          connectInputs.push(input)
+          return mockConnection
+        }),
+        disconnectNats: fromPromise(async () => {}),
+        subject: mockSubjectMachine,
+        kv: mockKvMachine,
+      },
+    })
+    const actor = createActor(machine)
+    actor.start()
+    configureAndConnect(actor)
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+
+    actor.send({
+      type: 'CONFIGURE',
+      config: { opts: { debug: true, servers: ['ws://localhost:4225'] }, maxRetries: 2 },
+    })
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+    expect(connectInputs).toHaveLength(2)
+    expect(connectInputs[1].opts).toEqual({ debug: true, servers: ['ws://localhost:4225'] })
+    expect(actor.getSnapshot().context.natsConfig).toEqual({
+      opts: { debug: true, servers: ['ws://localhost:4225'] },
+      maxRetries: 2,
+    })
+    actor.stop()
+  })
+
+  it('should apply CONFIGURE and CONNECT sent while closing', async () => {
+    const disconnect = createDeferred<void>()
+    const connectInputs: any[] = []
+    const machine = natsMachine.provide({
+      actors: {
+        connectToNats: fromPromise(async ({ input }) => {
+          connectInputs.push(input)
+          return mockConnection
+        }),
+        disconnectNats: fromPromise(async () => disconnect.promise),
+        subject: mockSubjectMachine,
+        kv: mockKvMachine,
+      },
+    })
+    const actor = createActor(machine)
+    actor.start()
+    configureAndConnect(actor)
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+    actor.send({ type: 'DISCONNECT' })
+    expect(actor.getSnapshot().value).toBe('closing')
+
+    actor.send({
+      type: 'CONFIGURE',
+      config: { opts: { debug: true, servers: ['ws://localhost:4226'] }, maxRetries: 2 },
+    })
+    actor.send({ type: 'CONNECT' })
+    disconnect.resolve()
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+    expect(connectInputs).toHaveLength(2)
+    expect(connectInputs[1].opts).toEqual({ debug: true, servers: ['ws://localhost:4226'] })
+    expect(actor.getSnapshot().context.natsConfig).toEqual({
+      opts: { debug: true, servers: ['ws://localhost:4226'] },
+      maxRetries: 2,
+    })
     actor.stop()
   })
 

--- a/src/machines/root.ts
+++ b/src/machines/root.ts
@@ -19,6 +19,8 @@ export interface Context {
   retries: number
   subjectManagerReady: boolean
   kvManagerReady: boolean
+  configureAfterClose: boolean
+  connectAfterClose: boolean
 }
 
 // internal events and events from nats connection
@@ -54,6 +56,43 @@ export const natsMachine = setup({
       retries: (_) => 0,
       subjectManagerReady: (_) => false,
       kvManagerReady: (_) => false,
+      configureAfterClose: (_) => false,
+      connectAfterClose: (_) => false,
+    }),
+    configureNats: assign({
+      natsConfig: ({ event }) => {
+        if (event.type !== 'CONFIGURE') {
+          return undefined
+        }
+        return event.config
+      },
+      connection: (_) => null,
+      error: (_) => undefined,
+      retries: (_) => 0,
+      subjectManagerReady: (_) => false,
+      kvManagerReady: (_) => false,
+      configureAfterClose: (_) => false,
+      connectAfterClose: (_) => false,
+    }),
+    configureNatsAfterClose: assign({
+      natsConfig: ({ event }) => {
+        if (event.type !== 'CONFIGURE') {
+          return undefined
+        }
+        return event.config
+      },
+      error: (_) => undefined,
+      retries: (_) => 0,
+      subjectManagerReady: (_) => false,
+      kvManagerReady: (_) => false,
+      configureAfterClose: (_) => true,
+    }),
+    reconnectAfterClose: assign({
+      connectAfterClose: (_) => true,
+    }),
+    clearDeferredCloseActions: assign({
+      configureAfterClose: (_) => false,
+      connectAfterClose: (_) => false,
     }),
   },
   guards: {
@@ -62,6 +101,12 @@ export const natsMachine = setup({
       const subjectReady = context.subjectManagerReady
       const kvReady = context.kvManagerReady
       return hasValidConnection && subjectReady && kvReady
+    },
+    shouldConnectAfterClose: ({ context }) => {
+      return context.connectAfterClose && context.natsConfig !== undefined
+    },
+    shouldConfigureAfterClose: ({ context }) => {
+      return context.configureAfterClose && context.natsConfig !== undefined
     },
   },
   actors: {
@@ -80,6 +125,8 @@ export const natsMachine = setup({
     retries: 0,
     subjectManagerReady: false,
     kvManagerReady: false,
+    configureAfterClose: false,
+    connectAfterClose: false,
   },
   invoke: [
     { src: 'subject', id: 'subject', systemId: 'subject' },
@@ -101,11 +148,7 @@ export const natsMachine = setup({
       on: {
         CONFIGURE: {
           target: 'configured',
-          actions: [
-            assign({
-              natsConfig: ({ event }) => event.config,
-            }),
-          ],
+          actions: ['configureNats'],
           '*': {
             actions: [
               ({ event }: { event: any }) => {
@@ -117,7 +160,11 @@ export const natsMachine = setup({
       },
     },
     configured: {
+      entry: ['clearDeferredCloseActions'],
       on: {
+        CONFIGURE: {
+          actions: ['configureNats'],
+        },
         CONNECT: {
           target: 'connecting',
         },
@@ -135,6 +182,7 @@ export const natsMachine = setup({
       },
     },
     connecting: {
+      entry: ['clearDeferredCloseActions'],
       invoke: [
         {
           src: 'connectToNats',
@@ -186,6 +234,7 @@ export const natsMachine = setup({
     },
     connected: {
       entry: [
+        'clearDeferredCloseActions',
         (event) => {
           if (event.context.natsConfig?.opts.debug) {
             console.log('CONNECTED', event.context.connection?.getServer())
@@ -193,11 +242,17 @@ export const natsMachine = setup({
         },
       ],
       on: {
+        CONFIGURE: {
+          target: 'closing',
+          actions: ['configureNatsAfterClose', 'reconnectAfterClose'],
+        },
         DISCONNECT: {
           target: 'closing',
+          actions: ['clearDeferredCloseActions'],
         },
         CLOSE: {
           target: 'closing',
+          actions: ['clearDeferredCloseActions'],
         },
         'SUBJECT.*': {
           actions: [
@@ -248,9 +303,19 @@ export const natsMachine = setup({
       invoke: {
         src: 'disconnectNats',
         input: ({ context }) => ({ connection: context.connection }),
-        onDone: {
-          target: 'closed',
-        },
+        onDone: [
+          {
+            guard: 'shouldConnectAfterClose',
+            target: 'connecting',
+          },
+          {
+            guard: 'shouldConfigureAfterClose',
+            target: 'configured',
+          },
+          {
+            target: 'closed',
+          },
+        ],
         onError: {
           target: 'error',
           actions: assign({
@@ -258,9 +323,30 @@ export const natsMachine = setup({
           }),
         },
       },
+      on: {
+        CONFIGURE: {
+          actions: ['configureNatsAfterClose'],
+        },
+        CONNECT: {
+          actions: ['reconnectAfterClose'],
+        },
+      },
     },
     closed: {
+      entry: [
+        assign({
+          connection: (_) => null,
+          subjectManagerReady: (_) => false,
+          kvManagerReady: (_) => false,
+          configureAfterClose: (_) => false,
+          connectAfterClose: (_) => false,
+        }),
+      ],
       on: {
+        CONFIGURE: {
+          target: 'configured',
+          actions: ['configureNats'],
+        },
         RESET: {
           target: 'not_configured',
           actions: ['doReset'],
@@ -278,7 +364,12 @@ export const natsMachine = setup({
       },
     },
     error: {
+      entry: ['clearDeferredCloseActions'],
       on: {
+        CONFIGURE: {
+          target: 'configured',
+          actions: ['configureNats'],
+        },
         RESET: {
           target: 'not_configured',
           actions: ['doReset'],


### PR DESCRIPTION
## Summary

- treat `CONFIGURE` as a valid lifecycle event from configured, closed, error, connected, and closing states
- reconnect automatically when a connected NATS root machine is reconfigured
- defer `CONFIGURE` and `CONNECT` received during closing until the old connection has closed
- reset manager readiness/deferred reconnect flags when changing lifecycle state

## Why

The UI debug toggle exposed a root-machine bug: callers could send `CONFIGURE` while the NATS root machine was closing or closed, and the FSM would silently drop it. That left the old connection closed without starting the replacement connection.

This makes the lifecycle behavior explicit in `xstate-nats` instead of requiring callers to sequence around an internal race.

## Validation

- `pnpm build`
- `pnpm test` - 8 files / 117 tests passed
