### PR TITLE
fix: reconnect managers after nats reconfigure

### DIFF
--- a/src/machines/kv.ts
+++ b/src/machines/kv.ts
@@ -123,6 +123,7 @@ export const kvManagerLogic = setup({
   states: {
     kv_idle: {
       on: {
+        'KV.DISCONNECTED': {},
         'KV.CONNECT': {
           target: 'kv_check_sync',
           actions: [
@@ -135,7 +136,6 @@ export const kvManagerLogic = setup({
       },
     },
     kv_disconnecting: {
-      target: 'kv_idle',
       entry: [
         // dont close the connection here, it will be closed by the nats connection machine
         assign({
@@ -145,6 +145,9 @@ export const kvManagerLogic = setup({
         }),
         sendParent({ type: 'KV.DISCONNECTED' }),
       ],
+      always: {
+        target: 'kv_idle',
+      },
     },
     kv_connected: {
       entry: [sendParent({ type: 'KV.CONNECTED' })],
@@ -153,6 +156,18 @@ export const kvManagerLogic = setup({
         guard: 'hasPendingSync',
       },
       on: {
+        'KV.CONNECT': {
+          target: 'kv_check_sync',
+          actions: [
+            assign({
+              cachedConnection: ({ event }) => event.connection,
+              cachedKvm: ({ event }) => new Kvm(event.connection),
+            }),
+          ],
+        },
+        'KV.DISCONNECTED': {
+          target: 'kv_disconnecting',
+        },
         'KV.BUCKET_LIST': {
           actions: async ({ context, event }) => {
             try {
@@ -266,6 +281,11 @@ export const kvManagerLogic = setup({
       },
     },
     kv_check_sync: {
+      on: {
+        'KV.DISCONNECTED': {
+          target: 'kv_disconnecting',
+        },
+      },
       always: [
         {
           target: 'kv_syncing',
@@ -277,6 +297,11 @@ export const kvManagerLogic = setup({
       ],
     },
     kv_syncing: {
+      on: {
+        'KV.DISCONNECTED': {
+          target: 'kv_disconnecting',
+        },
+      },
       entry: [
         ({ context }) => {
           // either going to be 0 or 1 (if there were multiple syncs pending)
@@ -318,8 +343,17 @@ export const kvManagerLogic = setup({
     },
     kv_error: {
       on: {
+        'KV.DISCONNECTED': {
+          target: 'kv_disconnecting',
+        },
         'KV.CONNECT': {
           target: 'kv_check_sync',
+          actions: [
+            assign({
+              cachedConnection: ({ event }) => event.connection,
+              cachedKvm: ({ event }) => new Kvm(event.connection),
+            }),
+          ],
         },
       },
     },

--- a/src/machines/root.test.ts
+++ b/src/machines/root.test.ts
@@ -12,7 +12,9 @@ vi.mock('@nats-io/nats-core', async () => {
 })
 
 vi.mock('@nats-io/kv', () => ({
-  Kvm: vi.fn().mockImplementation(() => ({})),
+  Kvm: vi.fn().mockImplementation(function () {
+    return {}
+  }),
 }))
 
 const mockSubjectMachine = createMachine({
@@ -96,6 +98,11 @@ const mockConnection = {
       next: () => new Promise(() => {}),
     }),
   }),
+} as any
+
+const secondMockConnection = {
+  ...mockConnection,
+  getServer: vi.fn().mockReturnValue('ws://localhost:4223'),
 } as any
 
 function createDeferred<T>() {
@@ -433,6 +440,41 @@ describe('natsMachine', () => {
       opts: { debug: true, servers: ['ws://localhost:4225'] },
       maxRetries: 2,
     })
+    actor.stop()
+  })
+
+  it('should reconnect real managers when configured while connected', async () => {
+    const connections = [mockConnection, secondMockConnection]
+    const connectInputs: any[] = []
+    const machine = natsMachine.provide({
+      actors: {
+        connectToNats: fromPromise(async ({ input }) => {
+          connectInputs.push(input)
+          return connections.shift() ?? secondMockConnection
+        }),
+        disconnectNats: fromPromise(async () => {}),
+      },
+    })
+    const actor = createActor(machine)
+    actor.start()
+    configureAndConnect(actor)
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+
+    actor.send({
+      type: 'CONFIGURE',
+      config: { opts: { debug: true, servers: ['ws://localhost:4225'] }, maxRetries: 2 },
+    })
+
+    await vi.waitFor(() => {
+      expect(actor.getSnapshot().value).toBe('connected')
+    })
+    expect(connectInputs).toHaveLength(2)
+    expect(actor.getSnapshot().context.connection).toBe(secondMockConnection)
+    expect(actor.getSnapshot().context.subjectManagerReady).toBe(true)
+    expect(actor.getSnapshot().context.kvManagerReady).toBe(true)
     actor.stop()
   })
 

--- a/src/machines/subject.ts
+++ b/src/machines/subject.ts
@@ -103,6 +103,7 @@ export const subjectManagerLogic = setup({
   states: {
     subject_idle: {
       on: {
+        'SUBJECT.DISCONNECTED': {},
         'SUBJECT.CONNECT': {
           target: 'subject_check_sync',
           actions: [
@@ -114,7 +115,6 @@ export const subjectManagerLogic = setup({
       },
     },
     subject_disconnecting: {
-      target: 'subject_idle',
       entry: [
         // dont close the connection here, it will be closed by the nats connection machine
         assign({
@@ -123,6 +123,9 @@ export const subjectManagerLogic = setup({
         }),
         sendParent({ type: 'SUBJECT.DISCONNECTED' }),
       ],
+      always: {
+        target: 'subject_idle',
+      },
     },
     subject_connected: {
       entry: [sendParent({ type: 'SUBJECT.CONNECTED' })],
@@ -131,6 +134,17 @@ export const subjectManagerLogic = setup({
         guard: 'hasPendingSync',
       },
       on: {
+        'SUBJECT.CONNECT': {
+          target: 'subject_check_sync',
+          actions: [
+            assign({
+              cachedConnection: ({ event }) => event.connection,
+            }),
+          ],
+        },
+        'SUBJECT.DISCONNECTED': {
+          target: 'subject_disconnecting',
+        },
         'SUBJECT.REQUEST': {
           actions: assign(({ event, context }) => {
             subjectRequest({
@@ -164,6 +178,11 @@ export const subjectManagerLogic = setup({
       },
     },
     subject_check_sync: {
+      on: {
+        'SUBJECT.DISCONNECTED': {
+          target: 'subject_disconnecting',
+        },
+      },
       always: [
         {
           target: 'subject_syncing',
@@ -175,6 +194,11 @@ export const subjectManagerLogic = setup({
       ],
     },
     subject_syncing: {
+      on: {
+        'SUBJECT.DISCONNECTED': {
+          target: 'subject_disconnecting',
+        },
+      },
       entry: [
         ({ context }) => {
           // either going to be 0 or 1 (if there were multiple syncs pending)
@@ -199,8 +223,16 @@ export const subjectManagerLogic = setup({
     },
     subject_error: {
       on: {
+        'SUBJECT.DISCONNECTED': {
+          target: 'subject_disconnecting',
+        },
         'SUBJECT.CONNECT': {
           target: 'subject_check_sync',
+          actions: [
+            assign({
+              cachedConnection: ({ event }) => event.connection,
+            }),
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary
- reset subject and KV managers on DISCONNECTED instead of leaving them in active/disconnecting states
- allow active/error managers to accept a replacement connection during reconnect
- add a root regression test with the real subject and KV manager machines for connected -> CONFIGURE -> reconnect

## Why
When the root machine reconfigured a connected NATS client, the socket closed and reconnected, but the child subject/KV managers could remain attached to the old connection. They ignored the next CONNECT and the root stayed in initialise_managers forever.

## Validation
- pnpm build
- pnpm test src/machines/root.test.ts
- pnpm test