### PR TITLE
fix: resubscribe managers after reconnect

### DIFF
--- a/src/machines/kv.test.ts
+++ b/src/machines/kv.test.ts
@@ -82,7 +82,12 @@ function createParentMachine(kvLogic?: any) {
         actions: assign({ childState: 'connected' }),
       },
       'KV.DISCONNECTED': {
-        actions: assign({ childState: 'disconnected' }),
+        actions: [
+          sendTo('kv', ({ event }: any) => {
+            return { ...event }
+          }),
+          assign({ childState: 'disconnected' }),
+        ],
       },
     },
     states: {
@@ -210,6 +215,50 @@ describe('kvManagerLogic', () => {
       const childSnap = parentActor.getSnapshot().children.kv?.getSnapshot()
       expect(childSnap?.value).toBe('kv_connected')
     })
+    parentActor.stop()
+  })
+
+  it('should resync retained subscription configs after disconnect and reconnect', async () => {
+    const syncInputs: any[] = []
+    const kvWithMockSync = kvManagerLogic.provide({
+      actors: {
+        kvConsolidateState: fromPromise(async ({ input }) => {
+          syncInputs.push(input)
+          return {
+            subscriptions: new Map([['Pair(b, k)', {} as any]]),
+          }
+        }),
+      },
+    })
+    const parentActor = createActor(createParentMachine(kvWithMockSync))
+    parentActor.start()
+
+    parentActor.send({
+      type: 'KV.SUBSCRIBE',
+      config: { bucket: 'b', key: 'k', callback: vi.fn() },
+    })
+
+    const firstConnection = createMockConnection()
+    parentActor.send({ type: 'KV.CONNECT', connection: firstConnection })
+    await vi.waitFor(() => {
+      expect(syncInputs).toHaveLength(1)
+    })
+
+    parentActor.send({ type: 'KV.DISCONNECTED' })
+    const disconnectedCtx = parentActor.getSnapshot().children.kv?.getSnapshot()?.context
+    expect(disconnectedCtx?.subscriptionConfigs.has('Pair(b, k)')).toBe(true)
+    expect(disconnectedCtx?.subscriptions.size).toBe(0)
+    expect(disconnectedCtx?.syncRequired).toBe(1)
+
+    const secondConnection = createMockConnection()
+    parentActor.send({ type: 'KV.CONNECT', connection: secondConnection })
+    await vi.waitFor(() => {
+      expect(syncInputs).toHaveLength(2)
+    })
+
+    const childSnap = parentActor.getSnapshot().children.kv?.getSnapshot()
+    expect(childSnap?.value).toBe('kv_connected')
+    expect(syncInputs[1].connection).toBe(secondConnection)
     parentActor.stop()
   })
 

--- a/src/machines/kv.ts
+++ b/src/machines/kv.ts
@@ -142,6 +142,8 @@ export const kvManagerLogic = setup({
           cachedConnection: null,
           cachedKvm: null,
           subscriptions: new Map<string, QueuedIterator<KvWatchEntry>>(),
+          syncRequired: ({ context }) =>
+            context.subscriptionConfigs.size > 0 ? Math.max(context.syncRequired, 1) : context.syncRequired,
         }),
         sendParent({ type: 'KV.DISCONNECTED' }),
       ],

--- a/src/machines/subject.test.ts
+++ b/src/machines/subject.test.ts
@@ -51,7 +51,12 @@ function createParentMachine() {
         actions: assign({ childState: 'connected' }),
       },
       'SUBJECT.DISCONNECTED': {
-        actions: assign({ childState: 'disconnected' }),
+        actions: [
+          sendTo('subject', ({ event }: any) => {
+            return { ...event }
+          }),
+          assign({ childState: 'disconnected' }),
+        ],
       },
     },
     states: {
@@ -165,6 +170,35 @@ describe('subjectManagerLogic', () => {
     const childSnap = parentActor.getSnapshot().children.subject?.getSnapshot()
     expect(childSnap?.value).toBe('subject_connected')
     expect(connection.subscribe).toHaveBeenCalledWith('test.sub', undefined)
+    parentActor.stop()
+  })
+
+  it('should resubscribe retained configs after disconnect and reconnect', () => {
+    const parentActor = createActor(createParentMachine())
+    parentActor.start()
+
+    parentActor.send({
+      type: 'SUBJECT.SUBSCRIBE',
+      config: { subject: 'test.sub', callback: vi.fn() },
+    })
+
+    const firstConnection = createMockConnection()
+    parentActor.send({ type: 'SUBJECT.CONNECT', connection: firstConnection })
+
+    expect(firstConnection.subscribe).toHaveBeenCalledWith('test.sub', undefined)
+
+    parentActor.send({ type: 'SUBJECT.DISCONNECTED' })
+    const disconnectedCtx = parentActor.getSnapshot().children.subject?.getSnapshot()?.context
+    expect(disconnectedCtx?.subscriptionConfigs.has('test.sub')).toBe(true)
+    expect(disconnectedCtx?.subscriptions.size).toBe(0)
+    expect(disconnectedCtx?.syncRequired).toBe(1)
+
+    const secondConnection = createMockConnection()
+    parentActor.send({ type: 'SUBJECT.CONNECT', connection: secondConnection })
+
+    const childSnap = parentActor.getSnapshot().children.subject?.getSnapshot()
+    expect(childSnap?.value).toBe('subject_connected')
+    expect(secondConnection.subscribe).toHaveBeenCalledWith('test.sub', undefined)
     parentActor.stop()
   })
 

--- a/src/machines/subject.ts
+++ b/src/machines/subject.ts
@@ -120,6 +120,8 @@ export const subjectManagerLogic = setup({
         assign({
           cachedConnection: null,
           subscriptions: new Map<string, Subscription>(),
+          syncRequired: ({ context }) =>
+            context.subscriptionConfigs.size > 0 ? Math.max(context.syncRequired, 1) : context.syncRequired,
         }),
         sendParent({ type: 'SUBJECT.DISCONNECTED' }),
       ],


### PR DESCRIPTION
## Summary
- mark retained subject subscriptions as needing sync when the subject manager disconnects
- mark retained KV watch configs as needing sync when the KV manager disconnects
- add regression tests for subject and KV reconnect resubscription

## Why
After root reconfiguration the NATS socket now reconnects and the root reaches connected, but the child managers had cleared their current subscription handles while leaving syncRequired at 0. That meant retained target subscriptions were not recreated on the new connection, so protocol logging went quiet and time-server/KV traffic stopped.

## Validation
- pnpm test src/machines/subject.test.ts
- pnpm test src/machines/kv.test.ts
- pnpm build
- pnpm test