### PR TITLE
feat: manage and observe short-lived NATS credentials with XState

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ source without teaching `xstate-nats` about that provider:
 ```typescript
 credentials: {
   refreshBeforeExpiryMs: 60_000,
+  diagnostics: true,
   adapter: {
     load: () => loadSessionCredentials(),
     refresh: (current) => refreshSessionCredentials(current),
@@ -271,20 +272,35 @@ and request/reply replier.
 
 ### Emitted spans
 
-| Span name               | Emitted by           | Attributes                               |
-| ----------------------- | -------------------- | ---------------------------------------- |
-| `xstate.nats.subscribe` | `SUBJECT.SUBSCRIBE`  | `subject`                                |
-| `xstate.nats.message`   | per received message | `subject`, `payload.bytes`               |
-| `xstate.nats.publish`   | `SUBJECT.PUBLISH`    | `subject`, `payload.bytes`               |
-| `xstate.nats.request`   | `SUBJECT.REQUEST`    | `subject`, `payload.bytes`, `timeout.ms` |
-| `xstate.nats.reconnect` | NATS status loop     | `reconnect.type`                         |
-| `xstate.nats.lifecycle` | root machine         | `xstate.state`, `xstate.event`           |
-| `xstate.nats.kv.watch`  | `KV.SUBSCRIBE`       | `bucket`, `key`                          |
-| `xstate.nats.kv.entry`  | per KV watch entry   | `bucket`, `key`, `operation`             |
+| Span name                         | Emitted by           | Attributes                                                               |
+| --------------------------------- | -------------------- | ------------------------------------------------------------------------ |
+| `xstate.nats.subscribe`           | `SUBJECT.SUBSCRIBE`  | `subject`                                                                |
+| `xstate.nats.message`             | per received message | `subject`, `payload.bytes`                                               |
+| `xstate.nats.publish`             | `SUBJECT.PUBLISH`    | `subject`, `payload.bytes`                                               |
+| `xstate.nats.request`             | `SUBJECT.REQUEST`    | `subject`, `payload.bytes`, `timeout.ms`                                 |
+| `xstate.nats.reconnect`           | NATS status loop     | `reconnect.type`                                                         |
+| `xstate.nats.lifecycle`           | root machine         | `xstate.state`, `xstate.event`                                           |
+| `xstate.nats.credentials.load`    | credential load      | `credentials.operation`, `credentials.timeout.ms`, `credentials.outcome` |
+| `xstate.nats.credentials.refresh` | credential refresh   | `credentials.operation`, `credentials.timeout.ms`, `credentials.outcome` |
+| `xstate.nats.kv.watch`            | `KV.SUBSCRIBE`       | `bucket`, `key`                                                          |
+| `xstate.nats.kv.entry`            | per KV watch entry   | `bucket`, `key`, `operation`                                             |
 
 All error paths record exceptions on the active span, set span status to
 `ERROR`, and emit a named event (`xstate.nats.error` / `xstate.nats.kv.error`)
 with a truncated stack.
+
+### Credential metrics
+
+| Metric name                                  | Type      | Attributes             |
+| -------------------------------------------- | --------- | ---------------------- |
+| `xstate.nats.credentials.operations`         | Counter   | `operation`, `outcome` |
+| `xstate.nats.credentials.operation.duration` | Histogram | `operation`, `outcome` |
+| `xstate.nats.credentials.state.transitions`  | Counter   | `state`                |
+
+Operations are `load` or `refresh`; outcomes are `success` or `error`. Durations are recorded in
+milliseconds. These low-cardinality metrics expose authentication rate, refresh frequency,
+latency, failures, expiry, and recovery trends without recording credential contents.
+A registered OpenTelemetry `MeterProvider` is required to export them.
 
 ### Lifecycle diagnostics
 
@@ -309,6 +325,10 @@ include state, event type, server URLs, debug/verbose flags, retry count, auth
 type, and manager readiness flags. They do not include credentials, JWTs, nkeys,
 signatures, passwords, tokens, or raw protocol frames.
 
+Set `credentials.diagnostics: true` for sanitized credential state and operation breadcrumbs.
+They contain only operation, outcome, duration, timeout, state, and pending-waiter count. Adapter
+error messages and credential contents are deliberately excluded from logs and traces.
+
 ### Enabling tracing
 
 `@opentelemetry/api` is a peer dependency — the consumer controls the installed
@@ -322,9 +342,7 @@ import { W3CTraceContextPropagator } from '@opentelemetry/core'
 import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 
 const provider = new BasicTracerProvider({
-  spanProcessors: [
-    /* your exporter */
-  ],
+  spanProcessors: [/* your exporter */],
 })
 trace.setGlobalTracerProvider(provider)
 propagation.setGlobalPropagator(new W3CTraceContextPropagator())

--- a/README.md
+++ b/README.md
@@ -88,19 +88,47 @@ send({
 })
 ```
 
-Set `config.requestHeaders` to provide headers immediately before every request. This is useful for
-short-lived credentials because the provider may refresh them before returning:
+For short-lived authentication, configure the built-in credential actor. The adapter is
+product-neutral: an application can obtain credentials from OIDC, a service account, or another
+source without teaching `xstate-nats` about that provider:
 
 ```typescript
-requestHeaders: async () => {
-  const requestHeaders = headers()
-  requestHeaders.set('authorization', `Bearer ${await getValidAccessToken()}`)
-  return requestHeaders
+credentials: {
+  refreshBeforeExpiryMs: 60_000,
+  adapter: {
+    load: () => loadSessionCredentials(),
+    refresh: (current) => refreshSessionCredentials(current),
+  },
 }
 ```
 
-Header preparation and the NATS round trip share the request's `opts.timeout`. Requests made while
-the connection is unavailable fail through `onRequestResult` instead of being left pending.
+Both adapter methods return a `NatsCredentials` value:
+
+```typescript
+const requestHeaders = headers()
+requestHeaders.set('authorization', `Bearer ${accessToken}`)
+
+return {
+  auth: {
+    type: 'decentralised',
+    sentinelB64,
+    user: userId,
+    pass: idToken,
+  },
+  requestHeaders,
+  expiresAt: tokenExpiryEpochMs,
+}
+```
+
+The credential actor loads once, shares concurrent callers, refreshes before expiry, and bounds
+each adapter operation (30 seconds by default). `CONNECT` waits for ready credentials. Every
+`SUBJECT.REQUEST` then obtains current headers immediately before sending; header preparation and
+the NATS round trip share the request's `opts.timeout`. NATS reconnect authentication reads the
+actor's current cached connection credential synchronously, as required by the NATS authenticator.
+
+If loading or refresh fails, or unrefreshable credentials expire, requests fail closed and an
+active NATS connection is closed. After the application has repaired its login/session, send
+`CREDENTIALS.RELOAD`, then `CONNECT`. Static non-expiring `auth` configuration remains supported.
 
 ### Key-Value Operations
 
@@ -174,9 +202,11 @@ The NATS machine operates in the following states:
 ### Main Exports
 
 - `natsMachine`: The main XState machine for NATS operations
+- `credentialMachine`: Generic short-lived credential lifecycle machine
 - `KvSubscriptionKey`: Type for KV subscription keys
 - `parseNatsResult`: Utility for parsing NATS operation results
 - `AuthConfig`: Type for authentication configuration
+- `NatsCredentialAdapter`, `NatsCredentialConfig`, `NatsCredentials`: Credential actor contracts
 
 ### Authentication
 
@@ -211,6 +241,7 @@ auth: {
 - `CONNECT`: Establish connection
 - `DISCONNECT`: Close connection
 - `RESET`: Reset to initial state
+- `CREDENTIALS.RELOAD`: Reload credentials after the application repairs its session
 
 #### Subject Events
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ requestHeaders: async () => {
 }
 ```
 
+Header preparation and the NATS round trip share the request's `opts.timeout`. Requests made while
+the connection is unavailable fail through `onRequestResult` instead of being left pending.
+
 ### Key-Value Operations
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ send({
 })
 ```
 
+Set `config.requestHeaders` to provide headers immediately before every request. This is useful for
+short-lived credentials because the provider may refresh them before returning:
+
+```typescript
+requestHeaders: async () => {
+  const requestHeaders = headers()
+  requestHeaders.set('authorization', `Bearer ${await getValidAccessToken()}`)
+  return requestHeaders
+}
+```
+
 ### Key-Value Operations
 
 ```typescript

--- a/src/actions/connection.test.ts
+++ b/src/actions/connection.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createActor } from 'xstate'
+import { createActor, waitFor } from 'xstate'
 import { parseNatsResult, connectToNats, disconnectNats } from './connection'
+import { credentialMachine } from '../machines/credentials'
 
 vi.mock('@nats-io/nats-core', async () => {
   const actual = await vi.importActual('@nats-io/nats-core')
@@ -8,6 +9,8 @@ vi.mock('@nats-io/nats-core', async () => {
     ...actual,
     wsconnect: vi.fn(),
     credsAuthenticator: vi.fn((_creds: Uint8Array) => 'mock-authenticator'),
+    usernamePasswordAuthenticator: vi.fn(() => 'mock-userpass-authenticator'),
+    tokenAuthenticator: vi.fn(() => 'mock-token-authenticator'),
   }
 })
 
@@ -44,6 +47,7 @@ describe('parseNatsResult', () => {
 describe('connectToNats', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   it('should call wsconnect with opts and no auth', async () => {
@@ -103,8 +107,7 @@ describe('connectToNats', () => {
 
     expect(wsconnect).toHaveBeenCalledWith({
       servers: ['ws://localhost:4222'],
-      user: 'admin',
-      pass: 'secret',
+      authenticator: 'mock-userpass-authenticator',
     })
   })
 
@@ -137,8 +140,62 @@ describe('connectToNats', () => {
 
     expect(wsconnect).toHaveBeenCalledWith({
       servers: ['ws://localhost:4222'],
-      token: 'my-token',
+      authenticator: 'mock-token-authenticator',
     })
+  })
+
+  it('uses the latest actor credential for reconnect authentication', async () => {
+    const { wsconnect, usernamePasswordAuthenticator } = await import('@nats-io/nats-core')
+    const expiresAt = Date.now() + 3_600_000
+    const mockConnection = {
+      status: () => ({
+        [Symbol.asyncIterator]: () => ({ next: () => new Promise(() => {}) }),
+      }),
+    }
+    vi.mocked(wsconnect).mockResolvedValue(mockConnection as any)
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce({
+        expiresAt,
+        auth: {
+          type: 'decentralised',
+          sentinelB64: btoa('sentinel'),
+          user: 'user',
+          pass: 'first',
+        },
+      })
+      .mockResolvedValueOnce({
+        expiresAt,
+        auth: {
+          type: 'decentralised',
+          sentinelB64: btoa('sentinel'),
+          user: 'user',
+          pass: 'second',
+        },
+      })
+    const credentialActor = createActor(credentialMachine, {
+      input: { adapter: { load } },
+    }).start()
+    const actor = createActor(connectToNats, {
+      input: {
+        opts: { servers: ['ws://localhost:4222'] },
+        credentialActor,
+      },
+    }).start()
+
+    await waitFor(actor, (snapshot) => snapshot.status === 'done')
+    const password = vi.mocked(usernamePasswordAuthenticator).mock.calls[0][1]
+    expect(typeof password).toBe('function')
+    expect((password as () => string)()).toBe('first')
+
+    credentialActor.send({ type: 'CREDENTIALS.RELOAD' })
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(credentialActor.getSnapshot().value).toBe('ready'))
+    expect((password as () => string)()).toBe('second')
+    const now = vi.spyOn(Date, 'now').mockReturnValue(expiresAt + 1)
+    expect(() => (password as () => string)()).toThrow('expired')
+    now.mockRestore()
+    credentialActor.stop()
   })
 
   it('should merge decentralised auth config', async () => {
@@ -177,9 +234,7 @@ describe('connectToNats', () => {
     expect(wsconnect).toHaveBeenCalledWith(
       expect.objectContaining({
         servers: ['ws://localhost:4222'],
-        authenticator: 'mock-authenticator',
-        user: 'nkey-user',
-        pass: 'nkey-pass',
+        authenticator: ['mock-authenticator', 'mock-userpass-authenticator'],
       }),
     )
   })
@@ -225,7 +280,7 @@ describe('connectToNats', () => {
     const actor = createActor(connectToNats, {
       input: {
         opts: { servers: ['ws://localhost:4222'], debug: true },
-        onStatus: event => statusEvents.push(event),
+        onStatus: (event) => statusEvents.push(event),
       },
     })
 

--- a/src/actions/connection.ts
+++ b/src/actions/connection.ts
@@ -5,13 +5,16 @@ import {
   Msg,
   NatsConnection,
   Status,
+  tokenAuthenticator,
+  usernamePasswordAuthenticator,
   wsconnect,
 } from '@nats-io/nats-core'
 import { KvEntry } from '@nats-io/kv'
 import { type AuthConfig } from './types'
 import { withSpan } from '../telemetry'
+import { CredentialActor, getCredentials } from '../machines/credentials'
 
-const makeAuthConfig = (auth?: AuthConfig) => {
+const makeAuthConfig = (auth?: AuthConfig, getLatest?: () => AuthConfig | undefined) => {
   if (!auth) {
     return {}
   }
@@ -19,18 +22,24 @@ const makeAuthConfig = (auth?: AuthConfig) => {
   if (auth.type === 'decentralised') {
     const decodedSentinel = atob(auth!.sentinelB64!)
     return {
-      authenticator: credsAuthenticator(new TextEncoder().encode(decodedSentinel)),
-      user: auth.user,
-      pass: auth.pass,
+      authenticator: [
+        credsAuthenticator(new TextEncoder().encode(decodedSentinel)),
+        usernamePasswordAuthenticator(
+          () => getLatest?.()?.user ?? auth.user!,
+          () => getLatest?.()?.pass ?? auth.pass!,
+        ),
+      ],
     }
   } else if (auth.type === 'userpass') {
     return {
-      user: auth.user,
-      pass: auth.pass,
+      authenticator: usernamePasswordAuthenticator(
+        () => getLatest?.()?.user ?? auth.user!,
+        () => getLatest?.()?.pass ?? auth.pass!,
+      ),
     }
   } else if (auth.type === 'token') {
     return {
-      token: auth.token,
+      authenticator: tokenAuthenticator(() => getLatest?.()?.token ?? auth.token!),
     }
   }
 
@@ -51,12 +60,23 @@ export const connectToNats = fromPromise(
     input: {
       opts: ConnectionOptions
       auth?: AuthConfig
+      credentialActor?: CredentialActor
       onStatus?: (event: InternalStatusEvents) => void
     }
   }): Promise<NatsConnection> => {
+    const credentials = input.credentialActor
+      ? await getCredentials(input.credentialActor)
+      : undefined
+    const auth = credentials?.auth ?? input.auth
     const mergedOpts: ConnectionOptions = {
       ...input.opts,
-      ...makeAuthConfig(input.auth),
+      ...makeAuthConfig(auth, () => {
+        const current = input.credentialActor?.getSnapshot().context.current
+        if (current?.expiresAt !== undefined && current.expiresAt <= Date.now()) {
+          throw new Error('NATS credentials expired')
+        }
+        return current?.auth
+      }),
     }
     const debug = Boolean(mergedOpts.debug)
     const nc = await wsconnect(mergedOpts)

--- a/src/actions/subject.test.ts
+++ b/src/actions/subject.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { headers, TimeoutError } from '@nats-io/nats-core'
 import { subjectConsolidateState, subjectRequest, subjectPublish } from './subject'
 import type { SubjectSubscriptionConfig } from './subject'
 
@@ -412,6 +413,125 @@ describe('subjectRequest', () => {
     )
     consoleSpy.mockRestore()
     expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('reports synchronous connection failures', async () => {
+    const connection = createMockConnection()
+    const requestError = new Error('connection closed')
+    connection.request.mockImplementation(() => {
+      throw requestError
+    })
+    const onRequestResult = vi.fn()
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 'test.closed',
+        payload: {},
+        callback: vi.fn(),
+        onRequestResult,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(onRequestResult).toHaveBeenCalledWith({ ok: false, error: requestError })
+    })
+  })
+
+  it('settles once when the response callback fails', async () => {
+    const connection = createMockConnection()
+    connection.request.mockResolvedValue({ json: () => ({}), string: () => '{}' })
+    const callbackError = new Error('response callback failed')
+    const onRequestResult = vi.fn()
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 'test.callback-fail',
+        payload: {},
+        callback: () => {
+          throw callbackError
+        },
+        onRequestResult,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(onRequestResult).toHaveBeenCalledWith({ ok: false, error: callbackError })
+    })
+    expect(onRequestResult).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports request-header provider failures without sending', async () => {
+    const connection = createMockConnection()
+    const providerError = new Error('token refresh failed')
+    const onRequestResult = vi.fn()
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 'test.auth-fail',
+        payload: {},
+        callback: vi.fn(),
+        onRequestResult,
+        requestHeaders: () => {
+          throw providerError
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(onRequestResult).toHaveBeenCalledWith({ ok: false, error: providerError })
+    })
+    expect(connection.request).not.toHaveBeenCalled()
+  })
+
+  it('uses one timeout for request headers and transport', async () => {
+    const connection = createMockConnection()
+    const onRequestResult = vi.fn()
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 'test.auth-timeout',
+        payload: {},
+        opts: { timeout: 10 } as any,
+        callback: vi.fn(),
+        onRequestResult,
+        requestHeaders: () => new Promise(() => {}),
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(onRequestResult).toHaveBeenCalledWith({
+        ok: false,
+        error: expect.any(TimeoutError),
+      })
+    })
+    expect(connection.request).not.toHaveBeenCalled()
+  })
+
+  it('passes only the remaining timeout to transport', async () => {
+    const connection = createMockConnection()
+    connection.request.mockResolvedValue({ json: () => ({}), string: () => '{}' })
+    const requestHeaders = headers()
+    requestHeaders.set('authorization', 'Bearer token')
+    const now = vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(125)
+
+    subjectRequest({
+      input: {
+        connection,
+        subject: 'test.remaining-timeout',
+        payload: {},
+        opts: { timeout: 100 } as any,
+        callback: vi.fn(),
+        requestHeaders: async () => requestHeaders,
+      },
+    })
+
+    await vi.waitFor(() => expect(connection.request).toHaveBeenCalled())
+    expect(connection.request.mock.calls[0][2].timeout).toBe(75)
+    now.mockRestore()
   })
 
   it('should log request errors for callers without onRequestResult', async () => {

--- a/src/actions/subject.ts
+++ b/src/actions/subject.ts
@@ -1,5 +1,6 @@
 import {
   Msg,
+  MsgHdrs,
   NatsConnection,
   PublishOptions,
   RequestOptions,
@@ -122,9 +123,19 @@ export const subjectRequest = ({
     callback: (data: any) => void
     onRequestResult?: (result: RequestResult) => void
     onDownloadBytes?: (bytes: number) => void
+    requestHeaders?: () => Promise<MsgHdrs | undefined>
   }
 }) => {
-  const { connection, subject, payload, opts, callback, onRequestResult, onDownloadBytes } = input
+  const {
+    connection,
+    subject,
+    payload,
+    opts,
+    callback,
+    onRequestResult,
+    onDownloadBytes,
+    requestHeaders,
+  } = input
   if (!connection) {
     throw new Error('NATS connection is not available')
   }
@@ -145,11 +156,18 @@ export const subjectRequest = ({
       // declares `timeout` as required but nats-core only enforces it when
       // opts is provided; cast preserves the "no opts = use conn default"
       // contract.
-      const headers = injectContextIntoHeaders(opts?.headers)
-      const requestOpts = (opts ? { ...opts, headers } : { headers }) as RequestOptions
+      const request = (providedHeaders?: MsgHdrs) => {
+        const headers = injectContextIntoHeaders(opts?.headers)
+        providedHeaders?.keys().forEach((key) => {
+          const value = providedHeaders.get(key)
+          if (value) headers.set(key, value)
+        })
+        const requestOpts = (opts ? { ...opts, headers } : { headers }) as RequestOptions
 
-      return connection
-        .request(subject, payload, requestOpts)
+        return connection.request(subject, payload, requestOpts)
+      }
+
+      return (requestHeaders ? requestHeaders().then(request) : request())
         .then((msg: Msg) => {
           onDownloadBytes?.(msg.data?.length ?? 0)
           callback(parseNatsResult(msg))

--- a/src/actions/subject.ts
+++ b/src/actions/subject.ts
@@ -1,4 +1,5 @@
 import {
+  deadline,
   Msg,
   MsgHdrs,
   NatsConnection,
@@ -6,6 +7,7 @@ import {
   RequestOptions,
   Subscription,
   SubscriptionOptions,
+  TimeoutError,
 } from '@nats-io/nats-core'
 import { parseNatsResult } from './connection'
 import {
@@ -24,6 +26,25 @@ export type SubjectSubscriptionConfig = {
 }
 
 export type RequestResult = { ok: true } | { ok: false; error: Error }
+
+function notifyRequestResult(
+  callback: ((result: RequestResult) => void) | undefined,
+  result: RequestResult,
+) {
+  try {
+    callback?.(result)
+  } catch (error) {
+    console.error('NATS request result callback failed', error)
+  }
+}
+
+export function rejectUnavailableRequest(event: {
+  onRequestResult?: (result: RequestResult) => void
+}) {
+  const error = new Error('NATS connection is not available')
+  notifyRequestResult(event.onRequestResult, { ok: false, error })
+  if (!event.onRequestResult) console.error(error.message)
+}
 
 export const subjectConsolidateState = ({
   input,
@@ -156,34 +177,55 @@ export const subjectRequest = ({
       // declares `timeout` as required but nats-core only enforces it when
       // opts is provided; cast preserves the "no opts = use conn default"
       // contract.
-      const request = (providedHeaders?: MsgHdrs) => {
+      const request = (providedHeaders?: MsgHdrs, timeout = opts?.timeout) => {
         const headers = injectContextIntoHeaders(opts?.headers)
         providedHeaders?.keys().forEach((key) => {
           const value = providedHeaders.get(key)
           if (value) headers.set(key, value)
         })
         const requestOpts = (opts ? { ...opts, headers } : { headers }) as RequestOptions
+        if (timeout !== undefined) requestOpts.timeout = timeout
 
-        return connection.request(subject, payload, requestOpts)
+        try {
+          return connection.request(subject, payload, requestOpts)
+        } catch (error) {
+          return Promise.reject(error)
+        }
       }
 
-      return (requestHeaders ? requestHeaders().then(request) : request())
-        .then((msg: Msg) => {
+      const timeout = opts?.timeout
+      const startedAt = performance.now()
+      const preparedHeaders = requestHeaders ? Promise.resolve().then(requestHeaders) : undefined
+      const send = preparedHeaders
+        ? (timeout === undefined ? preparedHeaders : deadline(preparedHeaders, timeout)).then(
+            (headers) => {
+              if (timeout === undefined) return request(headers)
+              const remaining = Math.floor(timeout - (performance.now() - startedAt))
+              if (remaining <= 0) throw new TimeoutError()
+              return request(headers, remaining)
+            },
+          )
+        : request()
+
+      const fail = (err: unknown) => {
+        recordError(span, 'xstate.nats.error', err)
+        const error = err instanceof Error ? err : new Error(String(err))
+        notifyRequestResult(onRequestResult, { ok: false, error })
+        if (!onRequestResult) {
+          console.error(`RequestReply error for subject "${subject}"`, err)
+        }
+      }
+
+      return send.then((msg: Msg) => {
+        try {
           onDownloadBytes?.(msg.data?.length ?? 0)
           callback(parseNatsResult(msg))
-          onRequestResult?.({ ok: true })
-        })
-        .catch((err) => {
-          // Record on span manually so we can swallow the rejection here —
-          // the original fire-and-forget API didn't propagate request errors
-          // to callers and changing that now would be a breaking behaviour.
-          recordError(span, 'xstate.nats.error', err)
-          const error = err instanceof Error ? err : new Error(String(err))
-          onRequestResult?.({ ok: false, error })
-          if (!onRequestResult) {
-            console.error(`RequestReply error for subject "${subject}"`, err)
-          }
-        })
+        } catch (error) {
+          fail(error)
+          return
+        }
+        notifyRequestResult(onRequestResult, { ok: true })
+      }, fail)
     },
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,15 @@ export { KvSubscriptionKey, type KvSubscriptionConfig } from './actions/kv'
 export { parseNatsResult } from './actions/connection'
 export { type AuthConfig } from './actions/types'
 export {
+  credentialMachine,
+  getCredentials,
+  type CredentialActor,
+  type CredentialContext,
+  type NatsCredentialAdapter,
+  type NatsCredentialConfig,
+  type NatsCredentials,
+} from './machines/credentials'
+export {
   byteLength as natsTrafficByteLength,
   createEmptyTrafficMetrics,
   recordTrafficMetric,

--- a/src/machines/credentials.telemetry.test.ts
+++ b/src/machines/credentials.telemetry.test.ts
@@ -1,0 +1,66 @@
+import { SpanStatusCode } from '@opentelemetry/api'
+import { createActor, waitFor } from 'xstate'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupInMemoryTracer, type OtelTestHarness } from '../../test/otel-setup'
+import * as telemetry from '../telemetry'
+import { credentialMachine, getCredentials } from './credentials'
+
+vi.mock('../telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../telemetry')>()
+  return {
+    ...actual,
+    recordCredentialOperation: vi.fn(actual.recordCredentialOperation),
+    recordCredentialState: vi.fn(actual.recordCredentialState),
+  }
+})
+
+describe('credential telemetry', () => {
+  let harness: OtelTestHarness
+
+  beforeEach(() => {
+    harness = setupInMemoryTracer()
+    vi.mocked(telemetry.recordCredentialOperation).mockClear()
+    vi.mocked(telemetry.recordCredentialState).mockClear()
+  })
+
+  afterEach(() => {
+    harness.teardown()
+    vi.restoreAllMocks()
+  })
+
+  it('records sanitized operation telemetry and diagnostics', async () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const secret = 'secret-token-value'
+    const actor = createActor(credentialMachine, {
+      input: {
+        diagnostics: true,
+        adapter: {
+          load: async () => {
+            throw new Error(`provider rejected ${secret}`)
+          },
+        },
+      },
+    }).start()
+
+    await expect(getCredentials(actor)).rejects.toThrow(secret)
+    await waitFor(actor, (snapshot) => snapshot.matches('failed'))
+
+    expect(telemetry.recordCredentialOperation).toHaveBeenCalledWith(
+      'load',
+      'error',
+      expect.any(Number),
+    )
+    expect(telemetry.recordCredentialState).toHaveBeenCalledWith('loading')
+    expect(telemetry.recordCredentialState).toHaveBeenCalledWith('failed')
+    expect(JSON.stringify(debug.mock.calls)).not.toContain(secret)
+
+    const span = harness.exporter
+      .getFinishedSpans()
+      .find((candidate) => candidate.name === 'xstate.nats.credentials.load')
+    expect(span?.status.code).toBe(SpanStatusCode.ERROR)
+    expect(
+      JSON.stringify({ status: span?.status, attributes: span?.attributes, events: span?.events }),
+    ).not.toContain(secret)
+    actor.stop()
+  })
+})

--- a/src/machines/credentials.test.ts
+++ b/src/machines/credentials.test.ts
@@ -1,0 +1,175 @@
+import { TimeoutError } from '@nats-io/nats-core'
+import { createActor, waitFor } from 'xstate'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { credentialMachine, getCredentials } from './credentials'
+
+describe('credentialMachine', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('loads once and shares the ready credentials', async () => {
+    const credentials = { auth: { type: 'token' as const, token: 'one' } }
+    const load = vi.fn(async () => credentials)
+    const actor = createActor(credentialMachine, { input: { adapter: { load } } }).start()
+
+    await expect(Promise.all([getCredentials(actor), getCredentials(actor)])).resolves.toEqual([
+      credentials,
+      credentials,
+    ])
+    expect(load).toHaveBeenCalledOnce()
+    expect(actor.getSnapshot().value).toBe('ready')
+    actor.stop()
+  })
+
+  it('deduplicates requests while refreshing near expiry', async () => {
+    let finishRefresh!: (value: { auth: { type: 'token'; token: string } }) => void
+    const refreshed = { auth: { type: 'token' as const, token: 'two' } }
+    const refresh = vi.fn(
+      () =>
+        new Promise<{ auth: { type: 'token'; token: string } }>((resolve) => {
+          finishRefresh = resolve
+        }),
+    )
+    const actor = createActor(credentialMachine, {
+      input: {
+        adapter: {
+          load: async () => ({
+            auth: { type: 'token' as const, token: 'one' },
+            expiresAt: Date.now() + 30_000,
+          }),
+          refresh,
+        },
+      },
+    }).start()
+
+    await waitFor(actor, (snapshot) => snapshot.matches('refreshing'))
+    const first = getCredentials(actor)
+    const second = getCredentials(actor)
+    finishRefresh(refreshed)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([refreshed, refreshed])
+    expect(refresh).toHaveBeenCalledOnce()
+    actor.stop()
+  })
+
+  it('proactively refreshes before credentials expire', async () => {
+    vi.useFakeTimers()
+    const now = new Date('2026-01-01T00:00:00Z')
+    vi.setSystemTime(now)
+    const refresh = vi.fn(async () => ({
+      auth: { type: 'token' as const, token: 'two' },
+      expiresAt: now.getTime() + 600_000,
+    }))
+    const actor = createActor(credentialMachine, {
+      input: {
+        refreshBeforeExpiryMs: 1_000,
+        adapter: {
+          load: async () => ({
+            auth: { type: 'token' as const, token: 'one' },
+            expiresAt: now.getTime() + 5_000,
+          }),
+          refresh,
+        },
+      },
+    }).start()
+
+    await vi.advanceTimersByTimeAsync(4_000)
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce())
+    await expect(getCredentials(actor)).resolves.toMatchObject({
+      auth: { token: 'two' },
+    })
+    actor.stop()
+  })
+
+  it('rejects expired credentials when no refresh adapter exists', async () => {
+    vi.useFakeTimers()
+    const actor = createActor(credentialMachine, {
+      input: {
+        adapter: {
+          load: async () => ({
+            auth: { type: 'token' as const, token: 'one' },
+            expiresAt: Date.now() + 10,
+          }),
+        },
+      },
+    }).start()
+
+    await vi.advanceTimersByTimeAsync(10)
+    await expect(getCredentials(actor)).rejects.toThrow('expired')
+    expect(actor.getSnapshot().value).toBe('expired')
+    actor.stop()
+  })
+
+  it('does not release an expired value returned by the initial load', async () => {
+    const actor = createActor(credentialMachine, {
+      input: {
+        adapter: {
+          load: async () => ({
+            auth: { type: 'token' as const, token: 'stale' },
+            expiresAt: Date.now() - 1,
+          }),
+        },
+      },
+    }).start()
+
+    await expect(getCredentials(actor)).rejects.toThrow('expired')
+    expect(actor.getSnapshot().value).toBe('expired')
+    actor.stop()
+  })
+
+  it('fails closed when refresh returns another stale value', async () => {
+    const actor = createActor(credentialMachine, {
+      input: {
+        adapter: {
+          load: async () => ({ expiresAt: Date.now() + 1_000 }),
+          refresh: async () => ({ expiresAt: Date.now() + 1_000 }),
+        },
+      },
+    }).start()
+
+    await expect(getCredentials(actor)).rejects.toThrow('too close to expiry')
+    expect(actor.getSnapshot().value).toBe('failed')
+    actor.stop()
+  })
+
+  it('bounds a hung adapter operation and fails all waiters', async () => {
+    const actor = createActor(credentialMachine, {
+      input: {
+        operationTimeoutMs: 5,
+        adapter: { load: () => new Promise(() => {}) },
+      },
+    }).start()
+
+    const first = getCredentials(actor)
+    const second = getCredentials(actor)
+    await expect(first).rejects.toBeInstanceOf(TimeoutError)
+    await expect(second).rejects.toBeInstanceOf(TimeoutError)
+    await waitFor(actor, (snapshot) => snapshot.matches('failed'))
+    actor.stop()
+  })
+
+  it('can reload after a failure', async () => {
+    const load = vi
+      .fn<() => Promise<{ auth: { type: 'token'; token: string } }>>()
+      .mockRejectedValueOnce(new Error('session unavailable'))
+      .mockResolvedValueOnce({ auth: { type: 'token', token: 'recovered' } })
+    const actor = createActor(credentialMachine, { input: { adapter: { load } } }).start()
+    await waitFor(actor, (snapshot) => snapshot.matches('failed'))
+
+    actor.send({ type: 'CREDENTIALS.RELOAD' })
+
+    await expect(getCredentials(actor)).resolves.toMatchObject({
+      auth: { token: 'recovered' },
+    })
+    expect(load).toHaveBeenCalledTimes(2)
+    actor.stop()
+  })
+
+  it('rejects immediately after the actor is stopped', async () => {
+    const actor = createActor(credentialMachine, {
+      input: { adapter: { load: async () => ({}) } },
+    }).start()
+    actor.stop()
+
+    await expect(getCredentials(actor)).rejects.toThrow('actor is stopped')
+  })
+})

--- a/src/machines/credentials.ts
+++ b/src/machines/credentials.ts
@@ -1,6 +1,7 @@
 import { deadline, MsgHdrs } from '@nats-io/nats-core'
 import { ActorRefFrom, assign, fromPromise, setup } from 'xstate'
 import { type AuthConfig } from '../actions/types'
+import { recordCredentialOperation, recordCredentialState, withSpan } from '../telemetry'
 
 export interface NatsCredentials {
   auth?: AuthConfig
@@ -22,6 +23,8 @@ export interface NatsCredentialConfig {
   operationTimeoutMs?: number
   /** Called when credentials expire or cannot be loaded/refreshed. */
   onUnavailable?: (error: Error) => void
+  /** Emit sanitized credential lifecycle debug logs. */
+  diagnostics?: boolean
 }
 
 type CredentialResult = { ok: true; credentials: NatsCredentials } | { ok: false; error: Error }
@@ -49,8 +52,70 @@ function refreshBeforeExpiry(config: NatsCredentialConfig): number {
   return config.refreshBeforeExpiryMs ?? 60_000
 }
 
-function runBounded<T>(operation: () => Promise<T>, timeout: number): Promise<T> {
-  return deadline(Promise.resolve().then(operation), timeout)
+function credentialDiagnostic(
+  config: NatsCredentialConfig,
+  event: string,
+  attributes: Record<string, string | number | boolean>,
+): void {
+  if (config.diagnostics) console.debug('xstate-nats credentials', { event, ...attributes })
+}
+
+async function runCredentialOperation<T>(
+  config: NatsCredentialConfig,
+  operation: 'load' | 'refresh',
+  fn: () => Promise<T>,
+): Promise<T> {
+  const timeout = operationTimeout(config)
+  const startedAt = performance.now()
+  credentialDiagnostic(config, 'operation.start', { operation, timeout_ms: timeout })
+  let originalError: unknown
+
+  try {
+    const result = await withSpan(
+      `xstate.nats.credentials.${operation}`,
+      'xstate.nats.credentials.error',
+      { 'credentials.operation': operation, 'credentials.timeout.ms': timeout },
+      async (span) => {
+        try {
+          const value = await deadline(Promise.resolve().then(fn), timeout)
+          span.setAttribute('credentials.outcome', 'success')
+          return value
+        } catch (error) {
+          originalError = error
+          span.setAttribute('credentials.outcome', 'error')
+          // Keep provider error messages, stacks, tokens, and claims out of traces.
+          throw new Error(`NATS credential ${operation} failed`)
+        }
+      },
+    )
+    const durationMs = performance.now() - startedAt
+    recordCredentialOperation(operation, 'success', durationMs)
+    credentialDiagnostic(config, 'operation.finish', {
+      operation,
+      outcome: 'success',
+      duration_ms: durationMs,
+    })
+    return result
+  } catch {
+    const durationMs = performance.now() - startedAt
+    recordCredentialOperation(operation, 'error', durationMs)
+    credentialDiagnostic(config, 'operation.finish', {
+      operation,
+      outcome: 'error',
+      duration_ms: durationMs,
+    })
+    throw originalError ?? new Error(`NATS credential ${operation} failed`)
+  }
+}
+
+function credentialStateEntry(state: Parameters<typeof recordCredentialState>[0]) {
+  return ({ context }: { context: CredentialContext }) => {
+    recordCredentialState(state)
+    credentialDiagnostic(context.config, 'state.enter', {
+      state,
+      pending_waiters: context.waiters.length,
+    })
+  }
 }
 
 function notify(waiter: Waiter, result: CredentialResult): void {
@@ -69,13 +134,23 @@ export const credentialMachine = setup({
   },
   actors: {
     load: fromPromise(({ input }: { input: NatsCredentialConfig }) =>
-      runBounded(input.adapter.load, operationTimeout(input)),
+      runCredentialOperation(input, 'load', input.adapter.load),
     ),
     refresh: fromPromise(
       ({ input }: { input: { config: NatsCredentialConfig; current: NatsCredentials } }) => {
         const refresh = input.config.adapter.refresh
         if (!refresh) throw new Error('NATS credentials cannot be refreshed')
-        return runBounded(() => refresh(input.current), operationTimeout(input.config))
+        return runCredentialOperation(input.config, 'refresh', async () => {
+          const credentials = await refresh(input.current)
+          const expiresAt = credentials.expiresAt
+          if (
+            expiresAt !== undefined &&
+            expiresAt - refreshBeforeExpiry(input.config) <= Date.now()
+          ) {
+            throw new Error('Refreshed NATS credentials are already expired or too close to expiry')
+          }
+          return credentials
+        })
       },
     ),
   },
@@ -114,13 +189,6 @@ export const credentialMachine = setup({
       const expiresAt = (event.output as NatsCredentials).expiresAt
       return expiresAt !== undefined && expiresAt <= Date.now()
     },
-    refreshOutputNotFresh: ({ context, event }) => {
-      if (!('output' in event)) return true
-      const expiresAt = (event.output as NatsCredentials).expiresAt
-      return (
-        expiresAt !== undefined && expiresAt - refreshBeforeExpiry(context.config) <= Date.now()
-      )
-    },
   },
   actions: {
     queue: assign({
@@ -141,13 +209,6 @@ export const credentialMachine = setup({
     storeCredentials: assign(({ event }) =>
       'output' in event ? { current: event.output as NatsCredentials, error: undefined } : {},
     ),
-    rejectRefreshOutput: assign(({ context }) => {
-      const error = new Error(
-        'Refreshed NATS credentials are already expired or too close to expiry',
-      )
-      context.waiters.forEach((waiter) => notify(waiter, { ok: false, error }))
-      return { waiters: [], error }
-    }),
     rejectWaiters: assign(({ context, event }) => {
       const error =
         'error' in event
@@ -174,6 +235,7 @@ export const credentialMachine = setup({
   context: ({ input }) => ({ config: input, waiters: [] }),
   states: {
     loading: {
+      entry: credentialStateEntry('loading'),
       on: {
         'CREDENTIALS.GET': { actions: 'queue' },
       },
@@ -189,6 +251,7 @@ export const credentialMachine = setup({
       },
     },
     ready: {
+      entry: credentialStateEntry('ready'),
       after: {
         credentialDeadline: [
           { guard: 'canRefresh', target: 'refreshing' },
@@ -205,21 +268,19 @@ export const credentialMachine = setup({
       },
     },
     refreshing: {
+      entry: credentialStateEntry('refreshing'),
       on: {
         'CREDENTIALS.GET': { actions: 'queue' },
       },
       invoke: {
         src: 'refresh',
         input: ({ context }) => ({ config: context.config, current: context.current! }),
-        onDone: [
-          { guard: 'refreshOutputNotFresh', target: 'failed', actions: 'rejectRefreshOutput' },
-          { target: 'ready', actions: 'acceptCredentials' },
-        ],
+        onDone: { target: 'ready', actions: 'acceptCredentials' },
         onError: { target: 'failed', actions: 'rejectWaiters' },
       },
     },
     expired: {
-      entry: ['markExpired', 'rejectWaiters', 'notifyUnavailable'],
+      entry: [credentialStateEntry('expired'), 'markExpired', 'rejectWaiters', 'notifyUnavailable'],
       on: {
         'CREDENTIALS.GET': {
           actions: ({ event }) =>
@@ -229,7 +290,7 @@ export const credentialMachine = setup({
       },
     },
     failed: {
-      entry: 'notifyUnavailable',
+      entry: [credentialStateEntry('failed'), 'notifyUnavailable'],
       on: {
         'CREDENTIALS.GET': {
           actions: ({ context, event }) =>

--- a/src/machines/credentials.ts
+++ b/src/machines/credentials.ts
@@ -1,0 +1,259 @@
+import { deadline, MsgHdrs } from '@nats-io/nats-core'
+import { ActorRefFrom, assign, fromPromise, setup } from 'xstate'
+import { type AuthConfig } from '../actions/types'
+
+export interface NatsCredentials {
+  auth?: AuthConfig
+  requestHeaders?: MsgHdrs
+  /** Epoch milliseconds after which these credentials must not be used. Use the earliest expiry. */
+  expiresAt?: number
+}
+
+export interface NatsCredentialAdapter {
+  load: () => Promise<NatsCredentials>
+  refresh?: (current: NatsCredentials) => Promise<NatsCredentials>
+}
+
+export interface NatsCredentialConfig {
+  adapter: NatsCredentialAdapter
+  /** Refresh this long before expiry. Defaults to 60 seconds. */
+  refreshBeforeExpiryMs?: number
+  /** Maximum duration of one adapter load or refresh. Defaults to 30 seconds. */
+  operationTimeoutMs?: number
+  /** Called when credentials expire or cannot be loaded/refreshed. */
+  onUnavailable?: (error: Error) => void
+}
+
+type CredentialResult = { ok: true; credentials: NatsCredentials } | { ok: false; error: Error }
+
+type Waiter = (result: CredentialResult) => void
+
+export interface CredentialContext {
+  config: NatsCredentialConfig
+  current?: NatsCredentials
+  waiters: Waiter[]
+  error?: Error
+}
+
+type Events = { type: 'CREDENTIALS.GET'; reply: Waiter } | { type: 'CREDENTIALS.RELOAD' }
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function operationTimeout(config: NatsCredentialConfig): number {
+  return config.operationTimeoutMs ?? 30_000
+}
+
+function refreshBeforeExpiry(config: NatsCredentialConfig): number {
+  return config.refreshBeforeExpiryMs ?? 60_000
+}
+
+function runBounded<T>(operation: () => Promise<T>, timeout: number): Promise<T> {
+  return deadline(Promise.resolve().then(operation), timeout)
+}
+
+function notify(waiter: Waiter, result: CredentialResult): void {
+  try {
+    waiter(result)
+  } catch (error) {
+    console.error('NATS credential waiter failed', error)
+  }
+}
+
+export const credentialMachine = setup({
+  types: {
+    context: {} as CredentialContext,
+    events: {} as Events,
+    input: {} as NatsCredentialConfig,
+  },
+  actors: {
+    load: fromPromise(({ input }: { input: NatsCredentialConfig }) =>
+      runBounded(input.adapter.load, operationTimeout(input)),
+    ),
+    refresh: fromPromise(
+      ({ input }: { input: { config: NatsCredentialConfig; current: NatsCredentials } }) => {
+        const refresh = input.config.adapter.refresh
+        if (!refresh) throw new Error('NATS credentials cannot be refreshed')
+        return runBounded(() => refresh(input.current), operationTimeout(input.config))
+      },
+    ),
+  },
+  delays: {
+    credentialDeadline: ({ context }) => {
+      const expiresAt = context.current?.expiresAt
+      if (expiresAt === undefined) return 2_147_483_647
+      const advance = context.config.adapter.refresh ? refreshBeforeExpiry(context.config) : 0
+      return Math.max(0, expiresAt - advance - Date.now())
+    },
+  },
+  guards: {
+    canRefresh: ({ context }) => Boolean(context.current && context.config.adapter.refresh),
+    hasExpiry: ({ context }) => context.current?.expiresAt !== undefined,
+    shouldRefreshNow: ({ context }) => {
+      const expiresAt = context.current?.expiresAt
+      return Boolean(
+        context.config.adapter.refresh &&
+        expiresAt !== undefined &&
+        expiresAt - refreshBeforeExpiry(context.config) <= Date.now(),
+      )
+    },
+    isExpired: ({ context }) => {
+      const expiresAt = context.current?.expiresAt
+      return expiresAt !== undefined && expiresAt <= Date.now()
+    },
+    outputShouldRefresh: ({ context, event }) => {
+      if (!('output' in event) || !context.config.adapter.refresh) return false
+      const expiresAt = (event.output as NatsCredentials).expiresAt
+      return (
+        expiresAt !== undefined && expiresAt - refreshBeforeExpiry(context.config) <= Date.now()
+      )
+    },
+    outputExpired: ({ event }) => {
+      if (!('output' in event)) return false
+      const expiresAt = (event.output as NatsCredentials).expiresAt
+      return expiresAt !== undefined && expiresAt <= Date.now()
+    },
+    refreshOutputNotFresh: ({ context, event }) => {
+      if (!('output' in event)) return true
+      const expiresAt = (event.output as NatsCredentials).expiresAt
+      return (
+        expiresAt !== undefined && expiresAt - refreshBeforeExpiry(context.config) <= Date.now()
+      )
+    },
+  },
+  actions: {
+    queue: assign({
+      waiters: ({ context, event }) =>
+        event.type === 'CREDENTIALS.GET' ? [...context.waiters, event.reply] : context.waiters,
+    }),
+    replyReady: ({ context, event }) => {
+      if (event.type === 'CREDENTIALS.GET' && context.current) {
+        notify(event.reply, { ok: true, credentials: context.current })
+      }
+    },
+    acceptCredentials: assign(({ context, event }) => {
+      if (!('output' in event)) return {}
+      const credentials = event.output as NatsCredentials
+      context.waiters.forEach((waiter) => notify(waiter, { ok: true, credentials }))
+      return { current: credentials, waiters: [], error: undefined }
+    }),
+    storeCredentials: assign(({ event }) =>
+      'output' in event ? { current: event.output as NatsCredentials, error: undefined } : {},
+    ),
+    rejectRefreshOutput: assign(({ context }) => {
+      const error = new Error(
+        'Refreshed NATS credentials are already expired or too close to expiry',
+      )
+      context.waiters.forEach((waiter) => notify(waiter, { ok: false, error }))
+      return { waiters: [], error }
+    }),
+    rejectWaiters: assign(({ context, event }) => {
+      const error =
+        'error' in event
+          ? asError(event.error)
+          : (context.error ?? new Error('NATS credentials are unavailable'))
+      context.waiters.forEach((waiter) => notify(waiter, { ok: false, error }))
+      return { waiters: [], error }
+    }),
+    markExpired: assign({
+      error: (_) => new Error('NATS credentials expired'),
+    }),
+    notifyUnavailable: ({ context }) => {
+      const error = context.error ?? new Error('NATS credentials are unavailable')
+      try {
+        context.config.onUnavailable?.(error)
+      } catch (callbackError) {
+        console.error('NATS credential unavailable callback failed', callbackError)
+      }
+    },
+  },
+}).createMachine({
+  id: 'credentials',
+  initial: 'loading',
+  context: ({ input }) => ({ config: input, waiters: [] }),
+  states: {
+    loading: {
+      on: {
+        'CREDENTIALS.GET': { actions: 'queue' },
+      },
+      invoke: {
+        src: 'load',
+        input: ({ context }) => context.config,
+        onDone: [
+          { guard: 'outputShouldRefresh', target: 'refreshing', actions: 'storeCredentials' },
+          { guard: 'outputExpired', target: 'expired', actions: 'storeCredentials' },
+          { target: 'ready', actions: 'acceptCredentials' },
+        ],
+        onError: { target: 'failed', actions: 'rejectWaiters' },
+      },
+    },
+    ready: {
+      after: {
+        credentialDeadline: [
+          { guard: 'canRefresh', target: 'refreshing' },
+          { guard: 'hasExpiry', target: 'expired' },
+        ],
+      },
+      on: {
+        'CREDENTIALS.GET': [
+          { guard: 'shouldRefreshNow', target: 'refreshing', actions: 'queue' },
+          { guard: 'isExpired', target: 'expired', actions: 'queue' },
+          { actions: 'replyReady' },
+        ],
+        'CREDENTIALS.RELOAD': { target: 'loading' },
+      },
+    },
+    refreshing: {
+      on: {
+        'CREDENTIALS.GET': { actions: 'queue' },
+      },
+      invoke: {
+        src: 'refresh',
+        input: ({ context }) => ({ config: context.config, current: context.current! }),
+        onDone: [
+          { guard: 'refreshOutputNotFresh', target: 'failed', actions: 'rejectRefreshOutput' },
+          { target: 'ready', actions: 'acceptCredentials' },
+        ],
+        onError: { target: 'failed', actions: 'rejectWaiters' },
+      },
+    },
+    expired: {
+      entry: ['markExpired', 'rejectWaiters', 'notifyUnavailable'],
+      on: {
+        'CREDENTIALS.GET': {
+          actions: ({ event }) =>
+            notify(event.reply, { ok: false, error: new Error('NATS credentials expired') }),
+        },
+        'CREDENTIALS.RELOAD': { target: 'loading' },
+      },
+    },
+    failed: {
+      entry: 'notifyUnavailable',
+      on: {
+        'CREDENTIALS.GET': {
+          actions: ({ context, event }) =>
+            notify(event.reply, {
+              ok: false,
+              error: context.error ?? new Error('NATS credentials are unavailable'),
+            }),
+        },
+        'CREDENTIALS.RELOAD': { target: 'loading' },
+      },
+    },
+  },
+})
+
+export type CredentialActor = ActorRefFrom<typeof credentialMachine>
+
+export function getCredentials(actor: CredentialActor): Promise<NatsCredentials> {
+  if (actor.getSnapshot().status === 'stopped') {
+    return Promise.reject(new Error('NATS credential actor is stopped'))
+  }
+  return new Promise((resolve, reject) => {
+    actor.send({
+      type: 'CREDENTIALS.GET',
+      reply: (result) => (result.ok ? resolve(result.credentials) : reject(result.error)),
+    })
+  })
+}

--- a/src/machines/root.test.ts
+++ b/src/machines/root.test.ts
@@ -182,8 +182,10 @@ describe('natsMachine', () => {
     actor.stop()
   })
 
-  it('forwards configured request headers to the subject manager', async () => {
-    const requestHeaders = vi.fn(async () => undefined)
+  it('forwards current credential headers to the subject manager', async () => {
+    const { headers } = await import('@nats-io/nats-core')
+    const requestHeaders = headers()
+    requestHeaders.set('authorization', 'Bearer current')
     const actor = createActor(createTestMachine())
     actor.start()
     actor.send({
@@ -191,7 +193,9 @@ describe('natsMachine', () => {
       config: {
         opts: { servers: ['ws://localhost:4222'] },
         maxRetries: 3,
-        requestHeaders,
+        credentials: {
+          adapter: { load: vi.fn(async () => ({ requestHeaders })) },
+        },
       },
     })
     actor.send({ type: 'CONNECT' })
@@ -202,14 +206,43 @@ describe('natsMachine', () => {
       subject: 'test.request',
       payload: {},
       callback: vi.fn(),
-      requestHeaders: vi.fn(async () => undefined),
     })
 
     await vi.waitFor(() => {
       expect(subjectEventSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ requestHeaders, type: 'SUBJECT.REQUEST' }),
+        expect.objectContaining({
+          requestHeaders: expect.any(Function),
+          type: 'SUBJECT.REQUEST',
+        }),
       )
     })
+    const forwarded = subjectEventSpy.mock.calls.at(-1)?.[0]
+    await expect(forwarded.requestHeaders()).resolves.toBe(requestHeaders)
+    actor.stop()
+  })
+
+  it('closes an active connection when credential refresh fails', async () => {
+    const actor = createActor(createTestMachine()).start()
+    actor.send({
+      type: 'CONFIGURE',
+      config: {
+        opts: { servers: ['ws://localhost:4222'] },
+        maxRetries: 3,
+        credentials: {
+          refreshBeforeExpiryMs: 5,
+          adapter: {
+            load: async () => ({ expiresAt: Date.now() + 100 }),
+            refresh: async () => {
+              throw new Error('refresh failed')
+            },
+          },
+        },
+      },
+    })
+    actor.send({ type: 'CONNECT' })
+    await vi.waitFor(() => expect(actor.getSnapshot().value).toBe('connected'))
+
+    await vi.waitFor(() => expect(actor.getSnapshot().value).toBe('closed'))
     actor.stop()
   })
 

--- a/src/machines/root.test.ts
+++ b/src/machines/root.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createActor, fromPromise, createMachine, sendParent } from 'xstate'
 import { natsMachine } from './root'
 
+const subjectEventSpy = vi.fn()
+
 vi.mock('@nats-io/nats-core', async () => {
   const actual = await vi.importActual<typeof import('@nats-io/nats-core')>('@nats-io/nats-core')
   return {
@@ -29,7 +31,7 @@ const mockSubjectMachine = createMachine({
     connected: {
       entry: sendParent({ type: 'SUBJECT.CONNECTED' }),
       on: {
-        'SUBJECT.*': {},
+        'SUBJECT.*': { actions: ({ event }) => subjectEventSpy(event) },
         'SUBJECT.DISCONNECTED': { target: 'idle' },
       },
     },
@@ -137,6 +139,7 @@ function configureAndConnect(actor: any) {
 
 describe('natsMachine', () => {
   beforeEach(() => {
+    subjectEventSpy.mockClear()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
@@ -176,6 +179,57 @@ describe('natsMachine', () => {
     expect(actor.getSnapshot().context.connection).toBe(mockConnection)
     expect(actor.getSnapshot().context.subjectManagerReady).toBe(true)
     expect(actor.getSnapshot().context.kvManagerReady).toBe(true)
+    actor.stop()
+  })
+
+  it('forwards configured request headers to the subject manager', async () => {
+    const requestHeaders = vi.fn(async () => undefined)
+    const actor = createActor(createTestMachine())
+    actor.start()
+    actor.send({
+      type: 'CONFIGURE',
+      config: {
+        opts: { servers: ['ws://localhost:4222'] },
+        maxRetries: 3,
+        requestHeaders,
+      },
+    })
+    actor.send({ type: 'CONNECT' })
+    await vi.waitFor(() => expect(actor.getSnapshot().value).toBe('connected'))
+
+    actor.send({
+      type: 'SUBJECT.REQUEST',
+      subject: 'test.request',
+      payload: {},
+      callback: vi.fn(),
+      requestHeaders: vi.fn(async () => undefined),
+    })
+
+    await vi.waitFor(() => {
+      expect(subjectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ requestHeaders, type: 'SUBJECT.REQUEST' }),
+      )
+    })
+    actor.stop()
+  })
+
+  it('fails requests immediately while disconnected', () => {
+    const actor = createActor(createTestMachine())
+    const onRequestResult = vi.fn()
+    actor.start()
+
+    actor.send({
+      type: 'SUBJECT.REQUEST',
+      subject: 'test.request',
+      payload: {},
+      callback: vi.fn(),
+      onRequestResult,
+    })
+
+    expect(onRequestResult).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.objectContaining({ message: 'NATS connection is not available' }),
+    })
     actor.stop()
   })
 

--- a/src/machines/root.ts
+++ b/src/machines/root.ts
@@ -1,5 +1,5 @@
-import { ConnectionOptions, MsgHdrs, NatsConnection } from '@nats-io/nats-core'
-import { assign, sendTo, setup } from 'xstate'
+import { ConnectionOptions, NatsConnection } from '@nats-io/nats-core'
+import { assign, sendTo, setup, stopChild } from 'xstate'
 import { kvManagerLogic, ExternalEvents as KvExternalEvents } from './kv'
 import { subjectManagerLogic, ExternalEvents as SubjectExternalEvents } from './subject'
 import { connectToNats, disconnectNats } from '../actions/connection'
@@ -8,6 +8,12 @@ import { InternalStatusEvents as NatsStatusEvents } from '../actions/connection'
 import { withSpan } from '../telemetry'
 import { NatsTrafficResetEvent } from '../traffic'
 import { rejectUnavailableRequest } from '../actions/subject'
+import {
+  CredentialActor,
+  credentialMachine,
+  getCredentials,
+  NatsCredentialConfig,
+} from './credentials'
 
 export interface NatsDiagnosticsConfig {
   lifecycle?: boolean
@@ -16,7 +22,7 @@ export interface NatsDiagnosticsConfig {
 export interface NatsConnectionConfig {
   opts: ConnectionOptions
   auth?: AuthConfig
-  requestHeaders?: () => Promise<MsgHdrs | undefined>
+  credentials?: NatsCredentialConfig
   maxRetries: number
   diagnostics?: NatsDiagnosticsConfig
 }
@@ -30,6 +36,7 @@ export interface Context {
   kvManagerReady: boolean
   configureAfterClose: boolean
   connectAfterClose: boolean
+  credentialActor?: CredentialActor
 }
 
 // internal events and events from nats connection
@@ -39,6 +46,7 @@ type InternalEvents =
   | { type: 'FAIL'; error: Error }
   | { type: 'RECONNECT' }
   | { type: 'CLOSE' }
+  | { type: 'CREDENTIALS.UNAVAILABLE'; error: Error }
   | NatsStatusEvents
 
 // events which can be sent to the machine from the user
@@ -47,6 +55,7 @@ export type ExternalEvents =
   | { type: 'CONNECT' }
   | { type: 'DISCONNECT' }
   | { type: 'RESET' }
+  | { type: 'CREDENTIALS.RELOAD' }
   | NatsTrafficResetEvent
   | SubjectExternalEvents
   | KvExternalEvents
@@ -74,7 +83,9 @@ function lifecycleAttributes(
     'nats.debug': Boolean(context.natsConfig?.opts.debug),
     'nats.verbose': Boolean(context.natsConfig?.opts.verbose),
     'nats.max_retries': context.natsConfig?.maxRetries,
-    'nats.auth.type': context.natsConfig?.auth?.type,
+    'nats.auth.type':
+      context.credentialActor?.getSnapshot().context.current?.auth?.type ??
+      context.natsConfig?.auth?.type,
     'nats.has_connection': context.connection !== null,
     'nats.subject_manager_ready': context.subjectManagerReady,
     'nats.kv_manager_ready': context.kvManagerReady,
@@ -105,6 +116,13 @@ export const natsMachine = setup({
     events: {} as Events,
   },
   actions: {
+    stopCredentialActor: stopChild(({ context }) => context.credentialActor as CredentialActor),
+    reloadCredentials: ({ context }) => {
+      context.credentialActor?.send({ type: 'CREDENTIALS.RELOAD' })
+    },
+    recordCredentialError: assign({
+      error: ({ event }) => (event.type === 'CREDENTIALS.UNAVAILABLE' ? event.error : undefined),
+    }),
     rejectUnavailableRequest: ({ event }) => {
       if (event.type !== 'SUBJECT.REQUEST') return
       rejectUnavailableRequest(event)
@@ -118,6 +136,7 @@ export const natsMachine = setup({
       kvManagerReady: (_) => false,
       configureAfterClose: (_) => false,
       connectAfterClose: (_) => false,
+      credentialActor: (_) => undefined,
     }),
     configureNats: assign({
       natsConfig: ({ event }) => {
@@ -133,6 +152,22 @@ export const natsMachine = setup({
       kvManagerReady: (_) => false,
       configureAfterClose: (_) => false,
       connectAfterClose: (_) => false,
+      credentialActor: ({ event, spawn, self }) => {
+        if (event.type !== 'CONFIGURE' || !event.config.credentials) return undefined
+        const onUnavailable = event.config.credentials.onUnavailable
+        return spawn('credentials', {
+          input: {
+            ...event.config.credentials,
+            onUnavailable: (error) => {
+              try {
+                onUnavailable?.(error)
+              } finally {
+                self.send({ type: 'CREDENTIALS.UNAVAILABLE', error })
+              }
+            },
+          },
+        })
+      },
     }),
     configureNatsAfterClose: assign({
       natsConfig: ({ event }) => {
@@ -146,6 +181,22 @@ export const natsMachine = setup({
       subjectManagerReady: (_) => false,
       kvManagerReady: (_) => false,
       configureAfterClose: (_) => true,
+      credentialActor: ({ event, spawn, self }) => {
+        if (event.type !== 'CONFIGURE' || !event.config.credentials) return undefined
+        const onUnavailable = event.config.credentials.onUnavailable
+        return spawn('credentials', {
+          input: {
+            ...event.config.credentials,
+            onUnavailable: (error) => {
+              try {
+                onUnavailable?.(error)
+              } finally {
+                self.send({ type: 'CREDENTIALS.UNAVAILABLE', error })
+              }
+            },
+          },
+        })
+      },
     }),
     reconnectAfterClose: assign({
       connectAfterClose: (_) => true,
@@ -174,6 +225,7 @@ export const natsMachine = setup({
     disconnectNats: disconnectNats,
     subject: subjectManagerLogic,
     kv: kvManagerLogic,
+    credentials: credentialMachine,
   },
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QAoC2BDAxgCwJYDswBKAOnwHsAXAfU3PwDNcoBXAJ0gGIBhAeQDkAYgEkA4gFUASgFEA2gAYAuolAAHcrFyVc9FSAAeiABwBOeSQBsAdgCMRgMwAmRxftWALPYCsAGhABPRHd3c3cvext7IwsveRCrAF8EvzQsPEJSOkZmdi4+fn5pbgAVBWUkEHVNbV0KwwQbGw9LJysLExNHSPkjP0CEdzaSMwsXaPt5LxMbeQsklIwcAmISLMJMbXwoTgh6MBICADdyAGt91KWM1fp1zagEI-JMdBr8MrK9Kq0dfD16m3CVhIUUcVis8isJjCjlmfUQ4XcLUcRiakXcJicc2SIAu6RWazAGwI2zAbDY5DYJFUABsXgwKagSLjlpkboS7g98Mdnq93kpPhpvrVQP9AcCjKDwZDobCAkF3DYSE0TNZ2p1ptF3PMcYs8az8Lc8gAZXgAZTk-IqX1ef0QNlGQK60TMEUGVi8NjhCFciJmGIxRmlYJs2uZV0w1MFWx2ewOXNO511LNWkc0W053JePz55TUgptdUQyK8JDiFiMXhC8hco3k9i9mJIVk17Rs03LYPsoaT4dTxM4pPJlJpdIZTJ7+L76cePOzSg+VvzP1tCGLpfc5cr8mrFlr9blDUrJFi2-kKs6NlB3bSyYjGi4MnNpUteeqy8LCCm9mB3kDtjBPRhA21bAme7bupukzXpcKyDhSnCPtIz65pUS7CgYdoWI0x4RG2IRNJ4jjuF6jgqk2LheJCbQRPYWrahQEBwHoYbEAKb7ofUAC0Fhetx0F6mQVC0PQTCsBwEBsUKvwflYXTkTE9qdq49gmA2jgls2FgbhuowmB4-G3iJOTiZJBYinacSKtYKoWHW7pGIGPEHm6JAhKMXikXYNieHRCw3uGbJElspnvuZDQRI4JAokRHkqjCG69M54TDLMXT2CpERmIk2IsfqhoSYu7HSWFTQqcMTrpVhKkool-SVhYx4uKlMylXYBm9lGUAhRxQSOF69omEq8gAruESTB5kTtZO94Fa+UkruiiqpdCHSOLhTn9E4GktjppH6TlE6kHBbDdcVGENFYZUXg49hVSYNVqeYMIRW07TqR42VJEAA */
@@ -187,24 +239,26 @@ export const natsMachine = setup({
     kvManagerReady: false,
     configureAfterClose: false,
     connectAfterClose: false,
+    credentialActor: undefined,
   },
   invoke: [
     { src: 'subject', id: 'subject', systemId: 'subject' },
     { src: 'kv', id: 'kv' },
   ],
-    on: {
-      'NATS_CONNECTION.CLOSE': {
-        target: '.closed',
-        actions: [
-          assign({
-            connection: (_) => null,
-            subjectManagerReady: (_) => false,
-            kvManagerReady: (_) => false,
-          }),
-          lifecycleAction('closed'),
-        ],
-      },
-      'NATS_CONNECTION.*': {
+  on: {
+    'CREDENTIALS.RELOAD': { actions: 'reloadCredentials' },
+    'NATS_CONNECTION.CLOSE': {
+      target: '.closed',
+      actions: [
+        assign({
+          connection: (_) => null,
+          subjectManagerReady: (_) => false,
+          kvManagerReady: (_) => false,
+        }),
+        lifecycleAction('closed'),
+      ],
+    },
+    'NATS_CONNECTION.*': {
       actions: [
         ({ context, event }: { context: Context; event: any }) => {
           recordLifecycle(context, event, 'status')
@@ -230,7 +284,7 @@ export const natsMachine = setup({
         'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'configured',
-          actions: ['configureNats'],
+          actions: ['stopCredentialActor', 'configureNats'],
           '*': {
             actions: [
               ({ event }: { event: any }) => {
@@ -246,7 +300,7 @@ export const natsMachine = setup({
       on: {
         'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
-          actions: ['configureNats', lifecycleAction('configured')],
+          actions: ['stopCredentialActor', 'configureNats', lifecycleAction('configured')],
         },
         CONNECT: {
           target: 'connecting',
@@ -254,7 +308,7 @@ export const natsMachine = setup({
         },
         RESET: {
           target: 'not_configured',
-          actions: ['doReset'],
+          actions: ['stopCredentialActor', 'doReset'],
         },
         '*': {
           actions: [
@@ -272,7 +326,7 @@ export const natsMachine = setup({
         CONFIGURE: {
           target: 'connecting',
           reenter: true,
-          actions: ['configureNats', lifecycleAction('connecting')],
+          actions: ['stopCredentialActor', 'configureNats', lifecycleAction('connecting')],
         },
         CONNECT: {
           actions: lifecycleAction('connecting'),
@@ -284,6 +338,7 @@ export const natsMachine = setup({
           input: ({ context, self }) => ({
             opts: context.natsConfig!.opts,
             auth: context.natsConfig!.auth,
+            credentialActor: context.credentialActor,
             onStatus: (event: NatsStatusEvents) => self.send(event),
           }),
           onDone: {
@@ -292,6 +347,7 @@ export const natsMachine = setup({
               lifecycleAction('connecting'),
               assign({
                 connection: ({ event }) => event.output,
+                error: (_) => undefined,
                 retries: (_) => 0,
               }),
             ],
@@ -323,6 +379,7 @@ export const natsMachine = setup({
         CONFIGURE: {
           target: 'closing',
           actions: [
+            'stopCredentialActor',
             'configureNatsAfterClose',
             'reconnectAfterClose',
             lifecycleAction('initialise_managers'),
@@ -348,6 +405,14 @@ export const natsMachine = setup({
         'KV.CONNECTED': {
           actions: [
             assign({ kvManagerReady: (_) => true }),
+            lifecycleAction('initialise_managers'),
+          ],
+        },
+        'CREDENTIALS.UNAVAILABLE': {
+          target: 'closing',
+          actions: [
+            'recordCredentialError',
+            'clearDeferredCloseActions',
             lifecycleAction('initialise_managers'),
           ],
         },
@@ -383,7 +448,12 @@ export const natsMachine = setup({
         },
         CONFIGURE: {
           target: 'closing',
-          actions: ['configureNatsAfterClose', 'reconnectAfterClose', lifecycleAction('connected')],
+          actions: [
+            'stopCredentialActor',
+            'configureNatsAfterClose',
+            'reconnectAfterClose',
+            lifecycleAction('connected'),
+          ],
         },
         DISCONNECT: {
           target: 'closing',
@@ -392,6 +462,14 @@ export const natsMachine = setup({
         CLOSE: {
           target: 'closing',
           actions: ['clearDeferredCloseActions', lifecycleAction('connected')],
+        },
+        'CREDENTIALS.UNAVAILABLE': {
+          target: 'closing',
+          actions: [
+            'recordCredentialError',
+            'clearDeferredCloseActions',
+            lifecycleAction('connected'),
+          ],
         },
         'SUBJECT.*': {
           actions: [
@@ -406,7 +484,14 @@ export const natsMachine = setup({
                 return {
                   ...event,
                   connection: context.connection,
-                  requestHeaders: context.natsConfig?.requestHeaders,
+                  requestHeaders: context.credentialActor
+                    ? () =>
+                        getCredentials(context.credentialActor!).then(
+                          (value) => value.requestHeaders,
+                        )
+                    : event.type === 'SUBJECT.REQUEST'
+                      ? event.requestHeaders
+                      : undefined,
                 }
               },
             ),
@@ -479,7 +564,7 @@ export const natsMachine = setup({
           actions: lifecycleAction('closing'),
         },
         CONFIGURE: {
-          actions: ['configureNatsAfterClose', lifecycleAction('closing')],
+          actions: ['stopCredentialActor', 'configureNatsAfterClose', lifecycleAction('closing')],
         },
         CONNECT: {
           actions: ['reconnectAfterClose', lifecycleAction('closing')],
@@ -503,11 +588,11 @@ export const natsMachine = setup({
         'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'configured',
-          actions: ['configureNats', lifecycleAction('closed')],
+          actions: ['stopCredentialActor', 'configureNats', lifecycleAction('closed')],
         },
         RESET: {
           target: 'not_configured',
-          actions: ['doReset'],
+          actions: ['stopCredentialActor', 'doReset'],
         },
         CONNECT: {
           target: 'connecting',
@@ -532,11 +617,11 @@ export const natsMachine = setup({
         },
         CONFIGURE: {
           target: 'configured',
-          actions: ['configureNats', lifecycleAction('error')],
+          actions: ['stopCredentialActor', 'configureNats', lifecycleAction('error')],
         },
         RESET: {
           target: 'not_configured',
-          actions: ['doReset'],
+          actions: ['stopCredentialActor', 'doReset'],
         },
       },
       '*': {

--- a/src/machines/root.ts
+++ b/src/machines/root.ts
@@ -7,6 +7,7 @@ import { type AuthConfig } from '../actions/types'
 import { InternalStatusEvents as NatsStatusEvents } from '../actions/connection'
 import { withSpan } from '../telemetry'
 import { NatsTrafficResetEvent } from '../traffic'
+import { rejectUnavailableRequest } from '../actions/subject'
 
 export interface NatsDiagnosticsConfig {
   lifecycle?: boolean
@@ -104,6 +105,10 @@ export const natsMachine = setup({
     events: {} as Events,
   },
   actions: {
+    rejectUnavailableRequest: ({ event }) => {
+      if (event.type !== 'SUBJECT.REQUEST') return
+      rejectUnavailableRequest(event)
+    },
     doReset: assign({
       natsConfig: (_) => undefined,
       connection: (_) => null,
@@ -222,6 +227,7 @@ export const natsMachine = setup({
   states: {
     not_configured: {
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'configured',
           actions: ['configureNats'],
@@ -238,6 +244,7 @@ export const natsMachine = setup({
     configured: {
       entry: ['clearDeferredCloseActions'],
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           actions: ['configureNats', lifecycleAction('configured')],
         },
@@ -261,6 +268,7 @@ export const natsMachine = setup({
     connecting: {
       entry: ['clearDeferredCloseActions', lifecycleAction('connecting')],
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'connecting',
           reenter: true,
@@ -311,6 +319,7 @@ export const natsMachine = setup({
         sendTo('kv', ({ context }) => ({ type: 'KV.CONNECT', connection: context.connection! })),
       ],
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'closing',
           actions: [
@@ -465,6 +474,7 @@ export const natsMachine = setup({
         },
       },
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         'NATS_CONNECTION.*': {
           actions: lifecycleAction('closing'),
         },
@@ -490,6 +500,7 @@ export const natsMachine = setup({
         }),
       ],
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONFIGURE: {
           target: 'configured',
           actions: ['configureNats', lifecycleAction('closed')],
@@ -514,6 +525,7 @@ export const natsMachine = setup({
     error: {
       entry: ['clearDeferredCloseActions', lifecycleAction('error')],
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         CONNECT: {
           target: 'connecting',
           actions: lifecycleAction('error'),

--- a/src/machines/root.ts
+++ b/src/machines/root.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions, NatsConnection } from '@nats-io/nats-core'
+import { ConnectionOptions, MsgHdrs, NatsConnection } from '@nats-io/nats-core'
 import { assign, sendTo, setup } from 'xstate'
 import { kvManagerLogic, ExternalEvents as KvExternalEvents } from './kv'
 import { subjectManagerLogic, ExternalEvents as SubjectExternalEvents } from './subject'
@@ -15,6 +15,7 @@ export interface NatsDiagnosticsConfig {
 export interface NatsConnectionConfig {
   opts: ConnectionOptions
   auth?: AuthConfig
+  requestHeaders?: () => Promise<MsgHdrs | undefined>
   maxRetries: number
   diagnostics?: NatsDiagnosticsConfig
 }
@@ -393,7 +394,11 @@ export const natsMachine = setup({
             sendTo(
               'subject',
               ({ event, context }: { event: SubjectExternalEvents; context: Context }) => {
-                return { ...event, connection: context.connection }
+                return {
+                  ...event,
+                  connection: context.connection,
+                  requestHeaders: context.natsConfig?.requestHeaders,
+                }
               },
             ),
           ],

--- a/src/machines/subject.test.ts
+++ b/src/machines/subject.test.ts
@@ -85,6 +85,26 @@ describe('subjectManagerLogic', () => {
     parentActor.stop()
   })
 
+  it('fails requests immediately while disconnected', () => {
+    const parentActor = createActor(createParentMachine())
+    const onRequestResult = vi.fn()
+    parentActor.start()
+
+    parentActor.send({
+      type: 'SUBJECT.REQUEST',
+      subject: 'test.req',
+      payload: {},
+      callback: vi.fn(),
+      onRequestResult,
+    })
+
+    expect(onRequestResult).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.objectContaining({ message: 'NATS connection is not available' }),
+    })
+    parentActor.stop()
+  })
+
   it('should have empty subscriptions initially', () => {
     const parentActor = createActor(createParentMachine())
     parentActor.start()
@@ -301,11 +321,14 @@ describe('subjectManagerLogic', () => {
       authHeaders.set('authorization', 'Bearer refreshed-token')
       return authHeaders
     })
+    const staleHeaders = headers()
+    staleHeaders.set('authorization', 'Bearer stale-token')
 
     parentActor.send({
       type: 'SUBJECT.REQUEST',
       subject: 'test.req',
       payload: { data: 1 },
+      opts: { headers: staleHeaders, timeout: 1000 },
       callback: vi.fn(),
       requestHeaders,
     })

--- a/src/machines/subject.test.ts
+++ b/src/machines/subject.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createActor, createMachine, assign, fromPromise, sendTo, setup } from 'xstate'
+import { headers } from '@nats-io/nats-core'
 import { subjectManagerLogic } from './subject'
 
 vi.mock('@nats-io/nats-core', async () => {
@@ -285,6 +286,42 @@ describe('subjectManagerLogic', () => {
       'test.req',
       { data: 1 },
       expect.objectContaining({ headers: expect.anything() }),
+    )
+    parentActor.stop()
+  })
+
+  it('gets request headers immediately before sending', async () => {
+    const parentActor = createActor(createParentMachine())
+    parentActor.start()
+
+    const connection = createMockConnection()
+    parentActor.send({ type: 'SUBJECT.CONNECT', connection })
+    const requestHeaders = vi.fn(async () => {
+      const authHeaders = headers()
+      authHeaders.set('authorization', 'Bearer refreshed-token')
+      return authHeaders
+    })
+
+    parentActor.send({
+      type: 'SUBJECT.REQUEST',
+      subject: 'test.req',
+      payload: { data: 1 },
+      callback: vi.fn(),
+      requestHeaders,
+    })
+
+    await vi.waitFor(() => {
+      expect(connection.request).toHaveBeenCalledWith(
+        'test.req',
+        { data: 1 },
+        expect.objectContaining({
+          headers: expect.objectContaining({ get: expect.any(Function) }),
+        }),
+      )
+    })
+    expect(requestHeaders).toHaveBeenCalledOnce()
+    expect(connection.request.mock.calls[0][2].headers.get('authorization')).toBe(
+      'Bearer refreshed-token',
     )
     parentActor.stop()
   })

--- a/src/machines/subject.ts
+++ b/src/machines/subject.ts
@@ -9,6 +9,7 @@ import { assign, sendParent, setup } from 'xstate'
 import {
   RequestResult,
   SubjectSubscriptionConfig,
+  rejectUnavailableRequest,
   subjectConsolidateState,
   subjectRequest,
   subjectPublish,
@@ -74,6 +75,12 @@ export const subjectManagerLogic = setup({
   guards: {
     hasPendingSync: ({ context }) => {
       return context.syncRequired > 0
+    },
+  },
+  actions: {
+    rejectUnavailableRequest: ({ event }) => {
+      if (event.type !== 'SUBJECT.REQUEST') return
+      rejectUnavailableRequest(event)
     },
   },
 }).createMachine({
@@ -157,6 +164,7 @@ export const subjectManagerLogic = setup({
   states: {
     subject_idle: {
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         'SUBJECT.DISCONNECTED': {},
         'SUBJECT.CONNECT': {
           target: 'subject_check_sync',
@@ -298,6 +306,7 @@ export const subjectManagerLogic = setup({
     },
     subject_error: {
       on: {
+        'SUBJECT.REQUEST': { actions: 'rejectUnavailableRequest' },
         'SUBJECT.DISCONNECTED': {
           target: 'subject_disconnecting',
         },

--- a/src/machines/subject.ts
+++ b/src/machines/subject.ts
@@ -1,4 +1,10 @@
-import { Subscription, PublishOptions, NatsConnection, RequestOptions } from '@nats-io/nats-core'
+import {
+  MsgHdrs,
+  Subscription,
+  PublishOptions,
+  NatsConnection,
+  RequestOptions,
+} from '@nats-io/nats-core'
 import { assign, sendParent, setup } from 'xstate'
 import {
   RequestResult,
@@ -41,6 +47,7 @@ export type ExternalEvents =
       opts?: RequestOptions
       callback: (data: any) => void
       onRequestResult?: (result: RequestResult) => void
+      requestHeaders?: () => Promise<MsgHdrs | undefined>
     }
   | { type: 'SUBJECT.SUBSCRIBE'; config: SubjectSubscriptionConfig }
   | { type: 'SUBJECT.UNSUBSCRIBE'; subject: string }
@@ -211,6 +218,7 @@ export const subjectManagerLogic = setup({
                 opts: event.opts,
                 callback: event.callback,
                 onRequestResult: event.onRequestResult,
+                requestHeaders: event.requestHeaders,
                 onDownloadBytes: (bytes) =>
                   self.send({
                     type: 'METRICS.RECORD',

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -14,12 +14,46 @@
 //     the per-message span so cross-process traces nest automatically.
 
 import type { Context, Span, Tracer } from '@opentelemetry/api'
-import { context as otelContext, propagation, SpanStatusCode, trace } from '@opentelemetry/api'
+import {
+  context as otelContext,
+  metrics,
+  propagation,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api'
 import type { MsgHdrs } from '@nats-io/nats-core'
 import { headers as natsHeaders } from '@nats-io/nats-core'
 import pkg from '../package.json' with { type: 'json' }
 
 const TRACER_NAME = '@jr200-labs/xstate-nats'
+const meter = metrics.getMeter(TRACER_NAME, pkg.version)
+const credentialOperations = meter.createCounter('xstate.nats.credentials.operations', {
+  description: 'Completed NATS credential operations',
+})
+const credentialDuration = meter.createHistogram('xstate.nats.credentials.operation.duration', {
+  description: 'NATS credential operation duration',
+  unit: 'ms',
+})
+const credentialStateTransitions = meter.createCounter(
+  'xstate.nats.credentials.state.transitions',
+  { description: 'NATS credential actor state transitions' },
+)
+
+export function recordCredentialOperation(
+  operation: 'load' | 'refresh',
+  outcome: 'success' | 'error',
+  durationMs: number,
+): void {
+  const attributes = { operation, outcome }
+  credentialOperations.add(1, attributes)
+  credentialDuration.record(durationMs, attributes)
+}
+
+export function recordCredentialState(
+  state: 'loading' | 'ready' | 'refreshing' | 'expired' | 'failed',
+): void {
+  credentialStateTransitions.add(1, { state })
+}
 
 // Do not cache — `trace.getTracer` already returns a lightweight ProxyTracer,
 // and caching across global-provider swaps (e.g. test teardown / re-register)


### PR DESCRIPTION
## Summary
- add a generic XState credential actor with loading, ready, refreshing, expired, and failed lifecycle states
- inject product-specific load and refresh adapters while keeping OIDC and Pocket ID concerns outside xstate-nats
- make CONNECT wait for ready credentials and make reconnect authentication read the latest cached credential synchronously
- obtain current application headers immediately before every SUBJECT.REQUEST within the existing request deadline
- deduplicate refresh waiters, proactively refresh before expiry, bound adapter operations, reject stale refresh results, and fail closed
- close active connections when credentials become unavailable and support explicit CREDENTIALS.RELOAD recovery
- emit credential load and refresh spans, operation counters, latency histograms, state-transition counters, and opt-in sanitized diagnostics
- keep adapter errors, tokens, headers, claims, and credential contents out of logs, traces, and metric attributes

## Verification
- pnpm test (153 passed)
- pnpm lint
- pnpm build
- git diff --check

Static non-expiring auth remains supported. Connection authentication covers publish, subscribe, request, and KV operations; request-level bearer headers are applied centrally to request/reply.