### PR TITLE
chore: update shared workflows to 0.1.31

### DIFF
--- a/.github/.shared-config.yaml
+++ b/.github/.shared-config.yaml
@@ -1,4 +1,4 @@
-ref: shared-v0.1.30
+ref: shared-v0.1.31
 workflows:
   - hygiene
   - node

--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ""
+      preview-id:
+        description: "Publish an immutable -pr preview without changing the latest tag"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -44,5 +49,6 @@ jobs:
       checkout-ref: ${{ fromJson(needs.configure.outputs.context).checkout-ref }}
       pnpm-run-test: ${{ github.event.inputs.pnpm-run-test || 'true' }}
       pnpm-publish-args: ${{ github.event.inputs.pnpm-publish-args || '' }}
+      preview-id: ${{ github.event.inputs.preview-id || '' }}
     secrets:
       npmjs_api_token: ${{ secrets.NPMJS_API_TOKEN }}


### PR DESCRIPTION
## Summary
- update the pinned shared workflow release
- expose immutable preview publishing through the generated npm caller

## Checks
- scripts/sync-shared-drift-check
- git diff --check